### PR TITLE
chore: adiciona database setup e migration da tabela usuarios

### DIFF
--- a/api/database/migrations/001_create_usuarios.sql
+++ b/api/database/migrations/001_create_usuarios.sql
@@ -1,0 +1,14 @@
+-- Migration: 001_create_usuarios
+-- Cria a tabela de usuários conforme documentado em modelo-dados.md
+
+CREATE TABLE IF NOT EXISTS usuarios (
+  id              INTEGER PRIMARY KEY AUTOINCREMENT,
+  nome            TEXT    NOT NULL,
+  email           TEXT    NOT NULL UNIQUE,
+  senha_hash      TEXT    NOT NULL,
+  criado_em       TEXT    NOT NULL DEFAULT (datetime('now')),
+  atualizado_em   TEXT    NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Índice para busca rápida por e-mail (login)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_usuarios_email ON usuarios(email);

--- a/api/database/run-migrations.js
+++ b/api/database/run-migrations.js
@@ -1,0 +1,103 @@
+import db from '../src/config/database.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const migrationsDir = path.resolve(__dirname, 'migrations');
+
+/**
+ * Cria a tabela de controle _migrations se não existir
+ */
+function criarTabelaControle() {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS _migrations (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      arquivo     TEXT    NOT NULL UNIQUE,
+      executada_em TEXT   NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}
+
+/**
+ * Retorna a lista de migrations já executadas
+ */
+function obterMigrationsExecutadas() {
+  const rows = db.prepare('SELECT arquivo FROM _migrations ORDER BY id').all();
+  return rows.map((row) => row.arquivo);
+}
+
+/**
+ * Retorna a lista de arquivos de migration disponíveis, em ordem
+ */
+function obterMigrationsDisponiveis() {
+  if (!fs.existsSync(migrationsDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(migrationsDir)
+    .filter((arquivo) => arquivo.endsWith('.sql'))
+    .sort();
+}
+
+/**
+ * Executa uma migration específica dentro de uma transação
+ */
+function executarMigration(arquivo) {
+  const caminho = path.join(migrationsDir, arquivo);
+  const sql = fs.readFileSync(caminho, 'utf-8');
+
+  const transacao = db.transaction(() => {
+    db.exec(sql);
+    db.prepare('INSERT INTO _migrations (arquivo) VALUES (?)').run(arquivo);
+  });
+
+  transacao();
+}
+
+/**
+ * Executa todas as migrations pendentes
+ */
+function executarMigrations() {
+  console.log('');
+  console.log('🔄 Iniciando execução de migrations...');
+  console.log('');
+
+  criarTabelaControle();
+
+  const executadas = obterMigrationsExecutadas();
+  const disponiveis = obterMigrationsDisponiveis();
+  const pendentes = disponiveis.filter((m) => !executadas.includes(m));
+
+  if (pendentes.length === 0) {
+    console.log('✅ Banco já está atualizado. Nenhuma migration pendente.');
+    console.log('');
+    return;
+  }
+
+  console.log(`📦 ${pendentes.length} migration(s) pendente(s) encontrada(s):`);
+  pendentes.forEach((m) => console.log(`   • ${m}`));
+  console.log('');
+
+  pendentes.forEach((arquivo) => {
+    try {
+      console.log(`⏳ Executando: ${arquivo}`);
+      executarMigration(arquivo);
+      console.log(`✅ Sucesso: ${arquivo}`);
+    } catch (erro) {
+      console.error(`❌ Erro ao executar ${arquivo}:`);
+      console.error(erro.message);
+      process.exit(1);
+    }
+  });
+
+  console.log('');
+  console.log(`🎉 ${pendentes.length} migration(s) aplicada(s) com sucesso!`);
+  console.log('');
+}
+
+// Execução
+executarMigrations();


### PR DESCRIPTION
## 📋 Descrição

Configura o sistema de migrations do banco SQLite e cria a primeira migration com a tabela `usuarios`, pré-requisito para implementação do EP-001.

## 🎯 O que foi feito

### Sistema de migrations
- ✅ Script `database/run-migrations.js` executável
- ✅ Tabela de controle `_migrations` criada automaticamente
- ✅ Migrations executadas em ordem alfabética/numérica
- ✅ Idempotência (migrations já aplicadas não são reexecutadas)
- ✅ Execução dentro de transação (atomicidade)

### Migration 001 — Tabela `usuarios`
- ✅ Arquivo `001_create_usuarios.sql` criado
- ✅ Colunas conforme documentado em `modelo-dados.md`:
  - `id` INTEGER PRIMARY KEY AUTOINCREMENT
  - `nome` TEXT NOT NULL
  - `email` TEXT NOT NULL UNIQUE
  - `senha_hash` TEXT NOT NULL
  - `criado_em` e `atualizado_em` com default `datetime('now')`
- ✅ Índice único `idx_usuarios_email` para login rápido

### Configuração do banco
- ✅ `PRAGMA foreign_keys = ON` (integridade referencial)
- ✅ `PRAGMA journal_mode = WAL` (performance)

## ✅ Validações realizadas

- [x] `npm run db:migrate` executa sem erros
- [x] Banco `provus.db` é criado na pasta `database/`
- [x] Tabela `usuarios` aparece no schema do SQLite
- [x] Estrutura da tabela confere com `modelo-dados.md`
- [x] Executar migration novamente não duplica (idempotência)
- [x] Índice único em `email` criado

## 📚 Regras de Negócio Cobertas

- `RG-002` — Prepared statements
- `RG-036` — Integridade referencial obrigatória
- `RU-003` — E-mail único (via UNIQUE constraint)
- `RU-004` — Senha persistida como hash (coluna `senha_hash`)

## 🎯 Tipo de mudança

- [x] Chore (infraestrutura / sem alteração de funcionalidade)

## 🔗 Issue relacionada

Closes #22