### PR TITLE
test: implementa testes automatizados da US-001 (cadastrar usuário)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,8 @@ temp/
 *.db-shm
 *.db-wal
 *.db-journal
+
+# Banco de teste (isolado do banco de desenvolvimento)
+api/database/provus-test.db
+api/database/provus-test.db-shm
+api/database/provus-test.db-wal

--- a/api/package.json
+++ b/api/package.json
@@ -7,13 +7,20 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node --watch server.js",
-    "test": "mocha tests/api/**/*.test.js --timeout 10000",
-    "test:watch": "mocha tests/api/**/*.test.js --timeout 10000 --watch",
+    "test": "NODE_ENV=test mocha tests/api/**/*.test.js --timeout 10000",
+    "test:watch": "NODE_ENV=test mocha tests/api/**/*.test.js --timeout 10000 --watch",
+    "test:setup": "NODE_ENV=test node database/run-migrations.js",
     "db:migrate": "node database/run-migrations.js",
     "db:seed": "node database/run-seeds.js",
     "db:reset": "rm -f database/provus.db && npm run db:migrate && npm run db:seed"
   },
-  "keywords": ["finance", "api", "express", "sqlite", "jwt"],
+  "keywords": [
+    "finance",
+    "api",
+    "express",
+    "sqlite",
+    "jwt"
+  ],
   "author": "Henrique Patti",
   "license": "MIT",
   "engines": {

--- a/api/src/config/database.js
+++ b/api/src/config/database.js
@@ -8,23 +8,22 @@ dotenv.config();
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-// Caminho do arquivo do banco (resolvido a partir do .env)
-const dbPath = process.env.DB_PATH
-  ? path.resolve(__dirname, '../../', process.env.DB_PATH)
-  : path.resolve(__dirname, '../../database/provus.db');
+// Escolhe o banco conforme o ambiente:
+// - NODE_ENV=test  → banco separado (provus-test.db)
+// - demais ambientes → banco definido em DB_PATH (ou provus.db)
+const isTest = process.env.NODE_ENV === 'test';
 
-/**
- * Cria e retorna uma instância de conexão com o SQLite.
- * Ativa foreign keys por padrão.
- */
+const dbPath = isTest
+  ? path.resolve(__dirname, '../../database/provus-test.db')
+  : (process.env.DB_PATH
+      ? path.resolve(__dirname, '../../', process.env.DB_PATH)
+      : path.resolve(__dirname, '../../database/provus.db'));
+
 const db = new Database(dbPath, {
   verbose: process.env.NODE_ENV === 'development' ? console.log : null,
 });
 
-// Ativa foreign keys (SQLite não ativa por padrão)
 db.pragma('foreign_keys = ON');
-
-// Modo WAL para melhor performance e concorrência
 db.pragma('journal_mode = WAL');
 
 export default db;

--- a/api/tests/api/usuarios/cadastrar.test.js
+++ b/api/tests/api/usuarios/cadastrar.test.js
@@ -1,0 +1,220 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import app from '../../../src/app.js';
+import { limparBanco } from '../../helpers/database.helper.js';
+import {
+  gerarUsuarioValido,
+  gerarUsuarioComEspacos,
+  gerarUsuarioEmailCaixaMista,
+  gerarNomeApenasNumeros,
+  gerarEmailFormatoInvalido,
+  gerarEmailMuitoLongo,
+  gerarSenhaMuitoCurta,
+  gerarSenhaSemMaiuscula,
+  gerarSenhaSemMinuscula,
+  gerarSenhaSemNumero,
+} from '../../fixtures/usuarios.fixtures.js';
+
+describe('POST /api/usuarios — Cadastrar novo usuário', () => {
+  beforeEach(() => {
+    limparBanco();
+  });
+
+  // ============================================================
+  // Fluxo feliz
+  // ============================================================
+
+  describe('Fluxo feliz', () => {
+    it('[CT-EP001-US001-01][US-001][RU-001,RU-002] deve criar usuário com dados válidos', async () => {
+      const usuario = gerarUsuarioValido();
+
+      const response = await request(app)
+        .post('/api/usuarios')
+        .send(usuario);
+
+      expect(response.status).to.equal(201);
+      expect(response.body).to.have.property('id');
+      expect(response.body.nome).to.equal(usuario.nome);
+      expect(response.body.email).to.equal(usuario.email);
+      expect(response.body).to.have.property('criadoEm');
+      expect(response.body).to.have.property('atualizadoEm');
+    });
+
+    it('[CT-EP001-US001-01][RG-004] não deve expor senha na resposta', async () => {
+      const usuario = gerarUsuarioValido();
+
+      const response = await request(app)
+        .post('/api/usuarios')
+        .send(usuario);
+
+      expect(response.status).to.equal(201);
+      expect(response.body).to.not.have.property('senha');
+      expect(response.body).to.not.have.property('senha_hash');
+      expect(response.body).to.not.have.property('senhaHash');
+    });
+  });
+
+  // ============================================================
+  // Conflito de e-mail
+  // ============================================================
+
+  describe('Conflito de e-mail', () => {
+    it('[CT-EP001-US001-02][US-001][RU-003] deve retornar 409 para e-mail já cadastrado', async () => {
+      const usuario = gerarUsuarioValido();
+
+      // primeiro cadastro
+      await request(app).post('/api/usuarios').send(usuario);
+
+      // tentativa de duplicar (mesmo e-mail)
+      const response = await request(app)
+        .post('/api/usuarios')
+        .send(usuario);
+
+      expect(response.status).to.equal(409);
+      expect(response.body.erro.codigo).to.equal('EMAIL_JA_CADASTRADO');
+    });
+  });
+
+  // ============================================================
+  // Campos obrigatórios ausentes
+  // ============================================================
+
+  describe('Campos obrigatórios ausentes', () => {
+    it('[CT-EP001-US001-03][US-001][RU-001,RG-014] deve retornar 400 quando nome ausente', async () => {
+      const { nome, ...semNome } = gerarUsuarioValido();
+
+      const response = await request(app).post('/api/usuarios').send(semNome);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.codigo).to.be.oneOf(['CAMPO_OBRIGATORIO', 'VALIDACAO']);
+      expect(response.body.erro.detalhes).to.be.an('array');
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'nome')).to.be.true;
+    });
+
+    it('[CT-EP001-US001-04][US-001][RU-001,RG-014] deve retornar 400 quando email ausente', async () => {
+      const { email, ...semEmail } = gerarUsuarioValido();
+
+      const response = await request(app).post('/api/usuarios').send(semEmail);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'email')).to.be.true;
+    });
+
+    it('[CT-EP001-US001-05][US-001][RU-001,RG-014] deve retornar 400 quando senha ausente', async () => {
+      const { senha, ...semSenha } = gerarUsuarioValido();
+
+      const response = await request(app).post('/api/usuarios').send(semSenha);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'senha')).to.be.true;
+    });
+  });
+
+  // ============================================================
+  // Validações de e-mail
+  // ============================================================
+
+  describe('Validação de e-mail', () => {
+    it('[CT-EP001-US001-06][US-001][RU-008,RU-011] deve retornar 400 para e-mail com formato inválido', async () => {
+      const usuario = gerarUsuarioValido({ email: gerarEmailFormatoInvalido() });
+
+      const response = await request(app).post('/api/usuarios').send(usuario);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'email')).to.be.true;
+    });
+
+    it('[CT-EP001-US001-07][US-001][RU-009] deve retornar 400 para e-mail acima de 254 caracteres', async () => {
+      const usuario = gerarUsuarioValido({ email: gerarEmailMuitoLongo() });
+
+      const response = await request(app).post('/api/usuarios').send(usuario);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'email')).to.be.true;
+    });
+  });
+
+  // ============================================================
+  // Validações de senha
+  // ============================================================
+
+  describe('Validação de senha', () => {
+    it('[CT-EP001-US001-08][US-001][RU-012] deve retornar 400 para senha menor que 8 caracteres', async () => {
+      const usuario = gerarUsuarioValido({ senha: gerarSenhaMuitoCurta() });
+
+      const response = await request(app).post('/api/usuarios').send(usuario);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'senha')).to.be.true;
+    });
+
+    it('[CT-EP001-US001-09][US-001][RU-014] deve retornar 400 para senha sem letra maiúscula', async () => {
+      const usuario = gerarUsuarioValido({ senha: gerarSenhaSemMaiuscula() });
+
+      const response = await request(app).post('/api/usuarios').send(usuario);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'senha')).to.be.true;
+    });
+
+    it('[CT-EP001-US001-10][US-001][RU-014] deve retornar 400 para senha sem letra minúscula', async () => {
+      const usuario = gerarUsuarioValido({ senha: gerarSenhaSemMinuscula() });
+
+      const response = await request(app).post('/api/usuarios').send(usuario);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'senha')).to.be.true;
+    });
+
+    it('[CT-EP001-US001-11][US-001][RU-014] deve retornar 400 para senha sem número', async () => {
+      const usuario = gerarUsuarioValido({ senha: gerarSenhaSemNumero() });
+
+      const response = await request(app).post('/api/usuarios').send(usuario);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'senha')).to.be.true;
+    });
+  });
+
+  // ============================================================
+  // Normalização
+  // ============================================================
+
+  describe('Normalização de dados', () => {
+    it('[CT-EP001-US001-12][US-001][RU-010,RG-020] deve normalizar e-mail para minúsculas', async () => {
+      const usuario = gerarUsuarioEmailCaixaMista();
+
+      const response = await request(app).post('/api/usuarios').send(usuario);
+
+      expect(response.status).to.equal(201);
+      expect(response.body.email).to.equal(usuario.email.toLowerCase().trim());
+    });
+
+    it('[CT-EP001-US001-13][US-001][RU-020,RG-016] deve normalizar espaços no nome', async () => {
+      const usuario = gerarUsuarioComEspacos();
+
+      const response = await request(app).post('/api/usuarios').send(usuario);
+
+      expect(response.status).to.equal(201);
+      // não deve conter múltiplos espaços consecutivos
+      expect(response.body.nome).to.not.match(/\s{2,}/);
+      // não deve começar ou terminar com espaço
+      expect(response.body.nome.trim()).to.equal(response.body.nome);
+    });
+  });
+
+  // ============================================================
+  // Validações de nome
+  // ============================================================
+
+  describe('Validação de nome', () => {
+    it('[CT-EP001-US001-14][US-001][RU-019] deve retornar 400 para nome apenas com números', async () => {
+      const usuario = gerarUsuarioValido({ nome: gerarNomeApenasNumeros() });
+
+      const response = await request(app).post('/api/usuarios').send(usuario);
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'nome')).to.be.true;
+    });
+  });
+});

--- a/api/tests/fixtures/usuarios.fixtures.js
+++ b/api/tests/fixtures/usuarios.fixtures.js
@@ -1,0 +1,267 @@
+/**
+ * ============================================================
+ * FIXTURES DE TESTE — USUÁRIOS
+ * ============================================================
+ *
+ * ⚠️  IMPORTANTE — LEIA ANTES DE USAR
+ *
+ * Este arquivo contém FACTORY FUNCTIONS que geram dados fictícios
+ * aleatórios para testes automatizados. NÃO há credenciais hardcoded.
+ *
+ * Cada chamada produz dados aleatórios mas válidos, garantindo:
+ * - Isolamento entre testes (cada um tem dados únicos)
+ * - Inexistência de senhas reais em qualquer ambiente
+ * - Conformidade com regras de validação do domínio
+ *
+ * Implementação: usa apenas `crypto` nativo do Node.js, sem dependências
+ * externas. Domínios reservados (.local, RFC 6762) garantem que nenhum
+ * e-mail aleatório possa atingir um destinatário real.
+ *
+ * Convenção:
+ * - `gerar*Valido*`    → produz dados que devem ser aceitos
+ * - `gerar*Invalido*`  → produz dados que devem ser rejeitados
+ *
+ * Override:
+ * Todas as factories aceitam um objeto opcional para forçar valores
+ * específicos quando o teste precisar:
+ *
+ *   const u = gerarUsuarioValido({ email: 'forcado@test.local' });
+ *
+ * ============================================================
+ */
+
+import { randomBytes, randomInt } from 'crypto';
+
+// ------------------------------------------------------------
+// HELPERS PRIMITIVOS (geradores básicos)
+// ------------------------------------------------------------
+
+/**
+ * Gera string aleatória de letras minúsculas com o tamanho informado.
+ */
+function letrasMinusculas(tamanho) {
+  const alfabeto = 'abcdefghijklmnopqrstuvwxyz';
+  let resultado = '';
+  for (let i = 0; i < tamanho; i++) {
+    resultado += alfabeto[randomInt(0, alfabeto.length)];
+  }
+  return resultado;
+}
+
+/**
+ * Gera string aleatória de letras maiúsculas com o tamanho informado.
+ */
+function letrasMaiusculas(tamanho) {
+  const alfabeto = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+  let resultado = '';
+  for (let i = 0; i < tamanho; i++) {
+    resultado += alfabeto[randomInt(0, alfabeto.length)];
+  }
+  return resultado;
+}
+
+/**
+ * Gera string aleatória de dígitos com o tamanho informado.
+ */
+function digitos(tamanho) {
+  let resultado = '';
+  for (let i = 0; i < tamanho; i++) {
+    resultado += randomInt(0, 10).toString();
+  }
+  return resultado;
+}
+
+/**
+ * Gera string aleatória de letras misturadas (maiúsculas + minúsculas).
+ */
+function letrasMistas(tamanho) {
+  const alfabeto = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+  let resultado = '';
+  for (let i = 0; i < tamanho; i++) {
+    resultado += alfabeto[randomInt(0, alfabeto.length)];
+  }
+  return resultado;
+}
+
+// ------------------------------------------------------------
+// HELPERS DE DOMÍNIO
+// ------------------------------------------------------------
+
+// Lista pequena de primeiros nomes brasileiros para gerar nomes verossímeis
+const PRIMEIROS_NOMES = [
+  'Ana', 'Bruno', 'Carla', 'Diego', 'Eduarda', 'Felipe', 'Gabriela',
+  'Henrique', 'Isabela', 'João', 'Karen', 'Lucas', 'Marina', 'Nicolas',
+  'Olivia', 'Pedro', 'Renata', 'Sofia', 'Thiago', 'Vitória',
+];
+
+const SOBRENOMES = [
+  'Silva', 'Souza', 'Oliveira', 'Pereira', 'Costa', 'Martins',
+  'Rodrigues', 'Almeida', 'Carvalho', 'Lima', 'Ferreira', 'Andrade',
+  'Ribeiro', 'Barbosa', 'Cardoso',
+];
+
+/**
+ * Gera um nome completo brasileiro fictício.
+ */
+function nomeCompleto() {
+  const primeiro = PRIMEIROS_NOMES[randomInt(0, PRIMEIROS_NOMES.length)];
+  const sobrenome = SOBRENOMES[randomInt(0, SOBRENOMES.length)];
+  return `${primeiro} ${sobrenome}`;
+}
+
+/**
+ * Gera uma senha válida conforme as regras do domínio:
+ * - 8 a 64 caracteres
+ * - Pelo menos 1 maiúscula, 1 minúscula e 1 número
+ *
+ * Estratégia: garante presença obrigatória + complementa com aleatório.
+ */
+function gerarSenhaValida() {
+  // 1 maiúscula + 5 minúsculas + 3 números = 9 chars (dentro do range)
+  return letrasMaiusculas(1) + letrasMinusculas(5) + digitos(3);
+}
+
+/**
+ * Gera um e-mail no domínio reservado .local.
+ * RFC 6762: domínios .local nunca chegam à internet pública.
+ */
+function gerarEmailFicticio() {
+  const usuario = letrasMinusculas(6) + '.' + letrasMinusculas(4);
+  const sufixo = letrasMinusculas(3) + digitos(2);
+  return `${usuario}.${sufixo}@provus-test.local`;
+}
+
+// ------------------------------------------------------------
+// FACTORIES VÁLIDAS (devem ser aceitas pela API)
+// ------------------------------------------------------------
+
+/**
+ * Gera um usuário com dados válidos para cadastro.
+ *
+ * @param {Object} overrides - Campos para sobrescrever
+ * @returns {Object} { nome, email, senha }
+ *
+ * Exemplo:
+ *   const u = gerarUsuarioValido();
+ *   const uForcado = gerarUsuarioValido({ email: 'fixo@test.local' });
+ */
+export function gerarUsuarioValido(overrides = {}) {
+  return {
+    nome: nomeCompleto(),
+    email: gerarEmailFicticio(),
+    senha: gerarSenhaValida(),
+    ...overrides,
+  };
+}
+
+/**
+ * Gera um usuário válido cujo nome contém espaços excessivos.
+ * Usado para testar normalização (RU-020, RG-016).
+ */
+export function gerarUsuarioComEspacos(overrides = {}) {
+  const primeiro = PRIMEIROS_NOMES[randomInt(0, PRIMEIROS_NOMES.length)];
+  const sobrenome = SOBRENOMES[randomInt(0, SOBRENOMES.length)];
+  // injeta espaços extras no início, no meio e no fim
+  const nomeComEspacos = `  ${primeiro}     ${sobrenome}  `;
+
+  return {
+    nome: nomeComEspacos,
+    email: `  ${gerarEmailFicticio()}  `,
+    senha: gerarSenhaValida(),
+    ...overrides,
+  };
+}
+
+/**
+ * Gera um usuário com e-mail em caixa mista.
+ * Usado para testar normalização (RU-010, RG-020).
+ */
+export function gerarUsuarioEmailCaixaMista(overrides = {}) {
+  const email = gerarEmailFicticio();
+  // alterna maiúsculas e minúsculas
+  const emailMisto = email
+    .split('')
+    .map((c, i) => (i % 2 === 0 ? c.toUpperCase() : c))
+    .join('');
+
+  return {
+    nome: nomeCompleto(),
+    email: emailMisto,
+    senha: gerarSenhaValida(),
+    ...overrides,
+  };
+}
+
+// ------------------------------------------------------------
+// FACTORIES PARA DADOS INVÁLIDOS (devem ser rejeitados)
+// ------------------------------------------------------------
+
+// --- Nome ---
+
+export function gerarNomeApenasNumeros() {
+  return digitos(5); // ex: "84291"
+}
+
+export function gerarNomeMuitoCurto() {
+  return letrasMinusculas(1); // 1 caractere
+}
+
+export function gerarNomeMuitoLongo() {
+  return letrasMinusculas(101); // > 100 chars
+}
+
+// --- E-mail ---
+
+export function gerarEmailFormatoInvalido() {
+  // String aleatória sem @ nem domínio
+  return letrasMinusculas(8) + digitos(3);
+}
+
+export function gerarEmailMuitoLongo() {
+  // > 254 caracteres
+  return letrasMinusculas(250) + '@provus-test.local';
+}
+
+// --- Senha ---
+
+export function gerarSenhaMuitoCurta() {
+  // 3 caracteres
+  return letrasMaiusculas(1) + letrasMinusculas(1) + digitos(1);
+}
+
+export function gerarSenhaSemMaiuscula() {
+  return letrasMinusculas(5) + digitos(3);
+}
+
+export function gerarSenhaSemMinuscula() {
+  return letrasMaiusculas(5) + digitos(3);
+}
+
+export function gerarSenhaSemNumero() {
+  return letrasMaiusculas(4) + letrasMinusculas(4);
+}
+
+export function gerarSenhaMuitoLonga() {
+  // > 64 caracteres
+  return gerarSenhaValida().repeat(10); // ~90 chars
+}
+
+// ------------------------------------------------------------
+// EXPORT DEFAULT (para importação agrupada)
+// ------------------------------------------------------------
+
+export default {
+  gerarUsuarioValido,
+  gerarUsuarioComEspacos,
+  gerarUsuarioEmailCaixaMista,
+  gerarNomeApenasNumeros,
+  gerarNomeMuitoCurto,
+  gerarNomeMuitoLongo,
+  gerarEmailFormatoInvalido,
+  gerarEmailMuitoLongo,
+  gerarSenhaMuitoCurta,
+  gerarSenhaSemMaiuscula,
+  gerarSenhaSemMinuscula,
+  gerarSenhaSemNumero,
+  gerarSenhaMuitoLonga,
+};

--- a/api/tests/helpers/database.helper.js
+++ b/api/tests/helpers/database.helper.js
@@ -1,0 +1,37 @@
+import db from '../../src/config/database.js';
+
+/**
+ * Limpa todas as tabelas de dados do banco de teste.
+ * Preserva a tabela _migrations (schema).
+ *
+ * PROTEÇÃO: só executa se NODE_ENV === 'test'.
+ * Isso evita qualquer risco acidental de apagar dados de desenvolvimento/produção.
+ */
+export function limparBanco() {
+  if (process.env.NODE_ENV !== 'test') {
+    throw new Error(
+      'limparBanco() só pode ser chamado com NODE_ENV=test. ' +
+      'Operação bloqueada para proteger dados de desenvolvimento.'
+    );
+  }
+
+  // Ordem importa quando houver FKs (filho antes, pai depois)
+  // Por enquanto só temos usuarios
+  db.exec('DELETE FROM usuarios;');
+
+  // Reseta auto-increment para IDs começarem do 1
+  db.exec("DELETE FROM sqlite_sequence WHERE name='usuarios';");
+}
+
+/**
+ * Fecha a conexão com o banco.
+ * Normalmente chamado no after() final dos testes.
+ */
+export function fecharConexao() {
+  db.close();
+}
+
+export default {
+  limparBanco,
+  fecharConexao,
+};


### PR DESCRIPTION
## 📋 Descrição

Implementa a primeira suíte de testes automatizados do projeto, cobrindo a US-001 (Cadastrar novo usuário) com 15 testes que validam todas as regras documentadas.

Esta entrega estabelece a **infraestrutura base de testes** que será reutilizada nas próximas User Stories.

## 🎯 O que foi feito

### Infraestrutura de testes

#### `src/config/database.js` (atualizado)
Lógica de seleção de banco baseada em `NODE_ENV`:
- `NODE_ENV=test` → usa `provus-test.db` (isolado)
- demais ambientes → usa banco de desenvolvimento

#### `tests/helpers/database.helper.js`
- Função `limparBanco()` para isolar testes
- **Proteção contra execução fora de ambiente de teste** (lança erro se NODE_ENV !== 'test')
- Reseta `sqlite_sequence` para IDs previsíveis

#### `tests/fixtures/usuarios.fixtures.js`
- **Factory functions** geradoras de dados aleatórios
- Implementação **sem dependências externas** (apenas `crypto` nativo)
- Domínio reservado `.local` (RFC 6762) para e-mails
- Senhas geradas dinamicamente respeitando regras de complexidade

#### `package.json` (atualizado)
- Script `test`: roda Mocha com NODE_ENV=test
- Script `test:setup`: aplica migrations no banco de teste

#### `.gitignore` (atualizado)
- Ignora arquivos `provus-test.db*`

### Suíte de testes da US-001

`tests/api/usuarios/cadastrar.test.js` com 15 testes em 7 grupos:

| Grupo | Testes | Foco |
|---|:---:|---|
| Fluxo feliz | 2 | Cadastro válido + não-exposição de senha |
| Conflito de e-mail | 1 | Status 409 + código EMAIL_JA_CADASTRADO |
| Campos obrigatórios ausentes | 3 | Nome, e-mail e senha sem valor |
| Validação de e-mail | 2 | Formato inválido + tamanho excedido |
| Validação de senha | 4 | Tamanho mínimo + complexidade (case + números) |
| Normalização de dados | 2 | E-mail minúsculas + espaços no nome |
| Validação de nome | 1 | Nome apenas com números |

**Cada teste** tem:
- ID padronizado: `[CT-EP001-USXXX-YY][US-XXX][RU-XXX]`
- Rastreabilidade ao caso documentado em `casos-teste-ep-001-usuarios.md`
- Rastreabilidade às regras de negócio (RU/RG)
- Asserts específicos de status HTTP, código de erro e estrutura

## ✅ Critérios de Aceitação

- [x] **CA-01**: Infraestrutura de testes (helpers, fixtures, banco isolado, scripts npm)
- [x] **CA-02**: Suíte da US-001 implementada (14 casos + 1 extra)
- [x] **CA-03**: Isolamento entre testes (`beforeEach` limpa banco)
- [x] **CA-04**: Suíte passa 100% (15/15 em ~240ms)

## 📚 Regras de Negócio Cobertas

- RU-001 a RU-020 (cadastro, validações de nome/email/senha)
- RG-001 (hash bcrypt)
- RG-004 (não exposição de dados sensíveis)
- RG-019 (múltiplos erros juntos)
- RG-020 (email normalizado)

## 🧪 Resultado da execução