### PR TITLE
fix: padroniza configuração de ambiente (porta 3000 e DB_PATH)

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -1,5 +1,5 @@
 # Porta em que a API vai rodar
-PORT=5000
+PORT=3000
 
 # Ambiente de execução (development, production, test)
 NODE_ENV=development

--- a/api/server.js
+++ b/api/server.js
@@ -3,7 +3,7 @@ import app from './src/app.js';
 
 dotenv.config();
 
-const PORT = process.env.PORT || 5000;
+const PORT = process.env.PORT || 3000;
 
 app.listen(PORT, () => {
   console.log('');

--- a/docs/03-arquitetura/stack-tecnologica.md
+++ b/docs/03-arquitetura/stack-tecnologica.md
@@ -199,7 +199,7 @@ NODE_ENV=development
 JWT_SECRET=<chave-secreta-gerada>
 JWT_EXPIRES_IN=24h
 BCRYPT_ROUNDS=10
-DATABASE_PATH=./database/provus.db
+DB_PATH=./database/provus.db
 ```
 
 ---

--- a/postman/Provus-Finance.postman_collection.json
+++ b/postman/Provus-Finance.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Provus Finance — Manual API Tests",
-    "description": "Coleção de testes **manuais e exploratórios** da API do Provus Finance.\n\n## Referências\n- `docs/06-testes/casos-teste-ep-001-usuarios.md`\n- `docs/05-user-stories/ep-001-usuarios.md`\n- `docs/06-testes/estrategia-testes.md`\n\n## Pré-requisitos\n1. API rodando: `cd api && npm start` (porta 5000 por padrão).\n2. Banco de desenvolvimento aplicado: `cd api && npm run db:migrate`.\n3. Para reexecutar a coleção do zero, resetar o banco: `cd api && npm run db:reset`.\n\n## Variáveis\n- `baseUrl` (definida na coleção): `http://localhost:5000`. Pode ser sobrescrita por environment.",
+    "description": "Coleção de testes **manuais e exploratórios** da API do Provus Finance.\n\n## Referências\n- `docs/06-testes/casos-teste-ep-001-usuarios.md`\n- `docs/05-user-stories/ep-001-usuarios.md`\n- `docs/06-testes/estrategia-testes.md`\n\n## Pré-requisitos\n1. API rodando: `cd api && npm start` (porta 3000 por padrão).\n2. Banco de desenvolvimento aplicado: `cd api && npm run db:migrate`.\n3. Para reexecutar a coleção do zero, resetar o banco: `cd api && npm run db:reset`.\n\n## Variáveis\n- `baseUrl` (definida na coleção): `http://localhost:3000`. Pode ser sobrescrita por environment.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -482,7 +482,7 @@
   "variable": [
     {
       "key": "baseUrl",
-      "value": "http://localhost:5000",
+      "value": "http://localhost:3000",
       "type": "string"
     }
   ]


### PR DESCRIPTION
## Resumo

Corrige duas divergências de configuração de ambiente entre código e documentação:

1. **Porta da API:** três artefatos (`server.js`, `.env.example`, coleção Postman) usavam `5000`, enquanto documentação (README, api-contratos, stack-tecnologica) e o fallback do Swagger usavam `3000`. Padroniza tudo em **3000**.
2. **Variável do banco:** o código lê `process.env.DB_PATH`, mas a doc `stack-tecnologica.md` listava como `DATABASE_PATH`. Padroniza a doc para **`DB_PATH`**.

## Mudanças

- `api/server.js` — fallback `PORT || 3000`
- `api/.env.example` — `PORT=3000` (mantém `DB_PATH`)
- `postman/Provus-Finance.postman_collection.json` — `baseUrl=http://localhost:3000` e descrição
- `docs/03-arquitetura/stack-tecnologica.md` — exemplo de `.env` agora usa `DB_PATH`

## Como testar

1. `cd api && npm install && cp .env.example .env`
2. `npm run db:migrate && npm start`
3. Verificar no console: `📍 Servidor: http://localhost:3000` (não mais 5000)
4. Abrir `http://localhost:3000/api-docs` — deve funcionar com a porta da doc.
5. Importar `postman/Provus-Finance.postman_collection.json` no Postman e rodar — todos os 14 requests devem bater em `localhost:3000`.
6. `cd api && npm test` — 15 testes Mocha continuam passando (testes não dependem de porta).

## Rastreabilidade

- Documentação que define o padrão: `docs/03-arquitetura/stack-tecnologica.md` (linha 197), `docs/03-arquitetura/api-contratos.md` (linhas 40 e 518), `README.md` (linhas 162-163)
- Origem da segunda divergência: `api/src/config/database.js` linha 18 (`process.env.DB_PATH`)