### PR TITLE
feat: implementa login com JWT (US-006)

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -5,6 +5,7 @@ import swaggerUi from 'swagger-ui-express';
 import swaggerSpec from './config/swagger.js';
 import healthRoutes from './routes/health.routes.js';
 import usuarioRoutes from './routes/usuario.routes.js';
+import authRoutes from './routes/auth.routes.js';
 import { errorMiddleware } from './middlewares/error.middleware.js';
 
 const app = express();
@@ -24,6 +25,7 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec, {
 // Rotas da API
 app.use('/api/health', healthRoutes);
 app.use('/api/usuarios', usuarioRoutes);
+app.use('/api/auth', authRoutes);
 
 // 404 para rotas não encontradas
 app.use((req, res) => {

--- a/api/src/config/swagger.js
+++ b/api/src/config/swagger.js
@@ -34,8 +34,8 @@ const swaggerOptions = {
     },
     tags: [
       { name: 'Sistema', description: 'Endpoints de sistema e saúde' },
-      { name: 'Autenticação', description: 'Login e geração de tokens' },
       { name: 'Usuários', description: 'Gestão de usuários' },
+      { name: 'Autenticação', description: 'Login e geração de tokens' },
       { name: 'Contas', description: 'Gestão de contas financeiras' },
       { name: 'Categorias', description: 'Gestão de categorias' },
       { name: 'Transações', description: 'Gestão de transações' },

--- a/api/src/controllers/auth.controller.js
+++ b/api/src/controllers/auth.controller.js
@@ -1,0 +1,21 @@
+import authService from '../services/auth.service.js';
+
+/**
+ * POST /api/auth/login
+ * Autentica um usuário com e-mail e senha e devolve um JWT.
+ */
+export async function login(req, res, next) {
+  try {
+    const { email, senha } = req.body || {};
+
+    const resultado = await authService.autenticar({ email, senha });
+
+    res.status(200).json(resultado);
+  } catch (erro) {
+    next(erro);
+  }
+}
+
+export default {
+  login,
+};

--- a/api/src/routes/auth.routes.js
+++ b/api/src/routes/auth.routes.js
@@ -1,0 +1,108 @@
+import { Router } from 'express';
+import authController from '../controllers/auth.controller.js';
+
+const router = Router();
+
+/**
+ * @swagger
+ * /api/auth/login:
+ *   post:
+ *     tags: [Autenticação]
+ *     summary: Autentica um usuário e devolve um JWT
+ *     description: |
+ *       Autentica um usuário e devolve um token JWT. Rota pública (não exige autenticação).
+ *
+ *       **Estrutura do token (payload):**
+ *       - sub — id do usuário
+ *       - email — e-mail do usuário (em minúsculas)
+ *       - iat — timestamp de emissão
+ *       - exp — timestamp de expiração (padrão 24h)
+ *
+ *       Por segurança, a resposta para e-mail não cadastrado e senha incorreta é exatamente a mesma (401 CREDENCIAIS_INVALIDAS), evitando enumeração de e-mails válidos.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email, senha]
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: "ana@provus.com"
+ *               senha:
+ *                 type: string
+ *                 format: password
+ *                 example: "Senha123"
+ *     responses:
+ *       200:
+ *         description: Autenticação bem-sucedida
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 token:
+ *                   type: string
+ *                   description: JWT assinado, válido por 24h
+ *                   example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+ *                 usuario:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       example: 1
+ *                     nome:
+ *                       type: string
+ *                       example: "Ana Martins"
+ *                     email:
+ *                       type: string
+ *                       format: email
+ *                       example: "ana@provus.com"
+ *       400:
+ *         description: Campos obrigatórios ausentes ou JSON malformado
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 erro:
+ *                   type: object
+ *                   properties:
+ *                     codigo:
+ *                       type: string
+ *                       enum: [CAMPO_OBRIGATORIO, FORMATO_INVALIDO]
+ *                       example: "CAMPO_OBRIGATORIO"
+ *                     mensagem:
+ *                       type: string
+ *                       example: "Um ou mais campos obrigatórios não foram informados."
+ *                     detalhes:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           campo:
+ *                             type: string
+ *                           problema:
+ *                             type: string
+ *       401:
+ *         description: Credenciais inválidas (e-mail não cadastrado ou senha incorreta)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 erro:
+ *                   type: object
+ *                   properties:
+ *                     codigo:
+ *                       type: string
+ *                       example: "CREDENCIAIS_INVALIDAS"
+ *                     mensagem:
+ *                       type: string
+ *                       example: "E-mail ou senha incorretos."
+ */
+router.post('/login', authController.login);
+
+export default router;

--- a/api/src/services/auth.service.js
+++ b/api/src/services/auth.service.js
@@ -1,0 +1,135 @@
+import usuarioRepository from '../repositories/usuario.repository.js';
+import { compararHash } from '../utils/hash.js';
+import { gerarToken } from '../utils/jwt.js';
+import { AppError } from '../middlewares/error.middleware.js';
+
+// ============================================================
+// VALIDAÇÕES
+// ============================================================
+
+/**
+ * Valida apenas a obrigatoriedade do e-mail no login.
+ *
+ * IMPORTANTE: o login NÃO valida formato/regex de e-mail. A validação
+ * de formato acontece no cadastro. No login basta verificar se o
+ * campo foi enviado — a comparação com a base já decide o resto.
+ */
+function validarEmail(email) {
+  if (typeof email !== 'string' || email.trim().length === 0) {
+    return { campo: 'email', problema: 'E-mail é obrigatório.' };
+  }
+  return null;
+}
+
+/**
+ * Valida apenas a obrigatoriedade da senha no login.
+ *
+ * IMPORTANTE: o login NÃO valida complexidade da senha (maiúscula,
+ * número etc.). Essa validação foi feita no cadastro. Aqui basta
+ * verificar se o campo foi enviado.
+ */
+function validarSenha(senha) {
+  if (typeof senha !== 'string' || senha.length === 0) {
+    return { campo: 'senha', problema: 'Senha é obrigatória.' };
+  }
+  return null;
+}
+
+/**
+ * Normaliza os dados de entrada do login.
+ *
+ * - email: trim + lowercase (RU-010, RG-020)
+ * - senha: NÃO sofre trim (espaços podem ser parte da senha)
+ */
+function normalizarDados({ email, senha }) {
+  return {
+    email: typeof email === 'string' ? email.trim().toLowerCase() : email,
+    senha,
+  };
+}
+
+/**
+ * Formata o objeto de usuário para a resposta da API,
+ * removendo qualquer campo sensível (senha_hash, timestamps internos).
+ */
+function formatarUsuario(usuario) {
+  return {
+    id: usuario.id,
+    nome: usuario.nome,
+    email: usuario.email,
+  };
+}
+
+// ============================================================
+// OPERAÇÕES
+// ============================================================
+
+/**
+ * Autentica um usuário com e-mail e senha e retorna um JWT.
+ *
+ * Regras críticas:
+ * - RU-022 (anti-enumeração): retorna o MESMO erro tanto quando o
+ *   e-mail não está cadastrado quanto quando a senha está incorreta.
+ *   O cliente não consegue distinguir os dois casos pela resposta.
+ * - RU-024: gera JWT assinado com a chave configurada e expiração
+ *   de 24h (configurável via JWT_EXPIRES_IN).
+ * - RU-025: payload do token contém { sub, email, iat, exp }.
+ *
+ * @param {Object} dados - { email, senha }
+ * @returns {Promise<{ token: string, usuario: { id, nome, email } }>}
+ * @throws {AppError} 400 CAMPO_OBRIGATORIO — campos ausentes/vazios
+ * @throws {AppError} 401 CREDENCIAIS_INVALIDAS — e-mail não cadastrado OU senha incorreta
+ */
+export async function autenticar(dados) {
+  const { email, senha } = normalizarDados(dados);
+
+  const erros = [];
+  const erroEmail = validarEmail(email);
+  if (erroEmail) erros.push(erroEmail);
+
+  const erroSenha = validarSenha(senha);
+  if (erroSenha) erros.push(erroSenha);
+
+  if (erros.length > 0) {
+    throw new AppError(
+      'CAMPO_OBRIGATORIO',
+      'Um ou mais campos obrigatórios não foram informados.',
+      400,
+      erros
+    );
+  }
+
+  const usuario = usuarioRepository.buscarPorEmail(email);
+
+  if (!usuario) {
+    throw new AppError(
+      'CREDENCIAIS_INVALIDAS',
+      'E-mail ou senha incorretos.',
+      401
+    );
+  }
+
+  const senhaConfere = await compararHash(senha, usuario.senha_hash);
+
+  if (!senhaConfere) {
+    throw new AppError(
+      'CREDENCIAIS_INVALIDAS',
+      'E-mail ou senha incorretos.',
+      401
+    );
+  }
+
+  const token = gerarToken({
+    sub: usuario.id,
+    email: usuario.email,
+  });
+
+  return {
+    token,
+    usuario: formatarUsuario(usuario),
+  };
+}
+
+export default {
+  autenticar,
+};


### PR DESCRIPTION
## 📋 Resumo

Implementa o endpoint **`POST /api/auth/login`**, fechando a **US-006** do EP-002 (Autenticação) e cobrindo todos os 9 critérios de aceite documentados em `docs/05-user-stories/ep-002-autenticacao.md`.

Este PR encerra a fase de implementação da User Story de login. Os testes automatizados (Mocha + Supertest) e a coleção Postman oficial virão em PRs separados (`test:`), seguindo exatamente o mesmo faseamento adotado na US-001.

---

## 🎯 O que entra

### Arquivos novos (3)

| Arquivo | Linhas | Responsabilidade |
|---|---:|---|
| `api/src/services/auth.service.js` | ~135 | Validação, busca, comparação de hash, geração de token, anti-enumeração |
| `api/src/controllers/auth.controller.js` | ~21 | Handler HTTP fino — orquestra request/response |
| `api/src/routes/auth.routes.js` | ~114 | Rota `POST /login` + JSDoc Swagger completo |

### Arquivos editados (2)

| Arquivo | Mudança |
|---|---|
| `api/src/app.js` | +2 linhas: `import authRoutes` + `app.use('/api/auth', authRoutes)` |
| `api/src/config/swagger.js` | Reordena as tags do Swagger UI: `Sistema → Usuários → Autenticação → Contas → ...`, refletindo a ordem de uso real (cadastro vem antes do login) |

**Total:** ~270 linhas adicionadas, 0 deletadas, 0 dependências novas.

---

## ♻️ Reaproveitamento de infraestrutura

Não foi necessário criar utilitários novos — toda a infraestrutura de auth já estava pronta no projeto desde o setup inicial:

| Já existia | Utilizado para |
|---|---|
| `utils/jwt.js` (`gerarToken`, `validarToken`) | Geração do JWT no login (US-006), validação será usada em US-007 |
| `utils/hash.js` (`compararHash`) | Verificação da senha contra o hash bcrypt |
| `repositories/usuario.repository.js` (`buscarPorEmail`) | Lookup do usuário no login |
| `middlewares/error.middleware.js` (`AppError` + handler) | Tratamento padronizado de todos os erros |
| `middlewares/auth.middleware.js` | Já cobre integralmente as US-007 e US-008 — basta plugar quando rotas protegidas existirem |

---

## 🛡️ Decisões de design relevantes para QA e segurança

### 1. Anti-enumeração (RU-022) — destaque do EP-002
O endpoint devolve **a mesma resposta** (`401 CREDENCIAIS_INVALIDAS`) tanto quando o e-mail não está cadastrado quanto quando a senha está incorreta. Não há diferença observável (status, código, mensagem, headers) entre os dois cenários. Esse é o comportamento mais crítico do épico do ponto de vista de segurança e está documentado de forma explícita no Swagger.

### 2. Validação mínima no login
O endpoint só verifica **obrigatoriedade** de `email` e `senha`. Validações de formato de e-mail e complexidade de senha pertencem ao cadastro (US-001) e não são repetidas aqui — isso evita criar uma porta de enumeração via mensagens de validação.

### 3. Normalização case-insensitive do e-mail (RU-010, RG-020)
O `email` informado é normalizado com `trim().toLowerCase()` antes do lookup, permitindo login mesmo com variações de capitalização (`ANA@PROVUS.COM` autentica o usuário `ana@provus.com`). A senha **não** sofre `trim` (espaços podem ser parte intencional dela).

### 4. Payload do JWT (RU-025, RG-013)
```json
{
  "sub": 1,
  "email": "ana@provus.com",
  "iat": 1714000000,
  "exp": 1714086400
}
```
- `sub` recebe o `id` do usuário (subject claim padrão JWT).
- `exp - iat` corresponde a **24h** (configurável via `JWT_EXPIRES_IN`).

### 5. Resposta enxuta
```json
{
  "token": "eyJ...",
  "usuario": { "id": 1, "nome": "Ana", "email": "ana@provus.com" }
}
```
Sem `senha`, sem `senha_hash`, sem timestamps internos.

---

## 🔗 Rastreabilidade

- **User Story:** US-006 (`docs/05-user-stories/ep-002-autenticacao.md`)
- **Casos de teste cobertos:** CT-EP002-US006-01 a CT-EP002-US006-09 (`docs/06-testes/casos-teste-ep-002-autenticacao.md`)
- **Regras de negócio aplicadas:**
  - `RU-010` — normalização do e-mail
  - `RU-021` — campos obrigatórios no login
  - `RU-022` — **anti-enumeração** (resposta idêntica para e-mail não cadastrado e senha incorreta)
  - `RU-023` — token JWT como retorno do login
  - `RU-024` — assinatura do JWT com chave configurada
  - `RU-025` — payload contém `sub`, `email`, `iat`, `exp`
  - `RU-026` — comparação segura de hash com bcrypt
  - `RU-027` — múltiplas sessões simultâneas suportadas (JWT stateless)
  - `RG-001` — autenticação obrigatória para rotas privadas
  - `RG-007` — tratamento de body inválido (`FORMATO_INVALIDO`)
  - `RG-013` — duração padrão de 24h
  - `RG-014` — campos obrigatórios em qualquer endpoint
  - `RG-020` — e-mails são case-insensitive
- **Documentos relacionados:**
  - `docs/03-arquitetura/api-contratos.md` (contrato de erro padronizado)
  - `docs/02-regras-negocio/regras-usuario.md`
  - `docs/02-regras-negocio/regras-gerais.md`

---

## 🧪 Validação realizada antes do commit

Smoke test manual via Postman cobrindo todos os 9 cenários da US-006:

| CT | Cenário | Status esperado | Resultado |
|---|---|:---:|:---:|
| CT-EP002-US006-01 | Login com credenciais válidas | 200 | ✅ |
| CT-EP002-US006-02 | E-mail não cadastrado | 401 `CREDENCIAIS_INVALIDAS` | ✅ |
| CT-EP002-US006-03 | Senha incorreta (anti-enumeração) | resposta idêntica ao CT-02 | ✅ |
| CT-EP002-US006-04 | Sem campo `email` | 400 `CAMPO_OBRIGATORIO` | ✅ |
| CT-EP002-US006-05 | Sem campo `senha` | 400 `CAMPO_OBRIGATORIO` | ✅ |
| CT-EP002-US006-06 | Body sem JSON válido | 400 `FORMATO_INVALIDO` | ✅ |
| CT-EP002-US006-07 | Payload do token correto | `{sub, email, iat, exp}` válidos | ✅ |
| CT-EP002-US006-08 | Login case-insensitive | 200 | ✅ |
| CT-EP002-US006-09 | Múltiplas sessões simultâneas | 200 + tokens distintos | ✅ |

Documentação Swagger validada em `http://localhost:3000/api-docs`:
- Tags renderizadas na ordem de uso: `Sistema → Usuários → Autenticação → ...`
- Endpoint `POST /api/auth/login` com descrição enxuta, alinhada ao estilo do `POST /api/usuarios`
- Request body, exemplos e responses 200/400/401 corretos

---

## ✅ Definition of Done parcial

- [x] Implementação do endpoint `POST /api/auth/login` cobrindo os 9 critérios de aceite
- [x] Anti-enumeração (RU-022) garantida e validada via comparação byte-a-byte
- [x] Documentação Swagger publicada em `/api-docs`
- [x] Smoke test manual com Postman aprovado (9/9)
- [x] Padrão arquitetural alinhado com US-001 (Route → Controller → Service → Repository)
- [ ] Testes automatizados em Mocha + Supertest (PR separado, próximo)
- [ ] Coleção Postman oficial da US-006 (PR separado, após o de testes)

---

## 🚦 Próximos passos (após merge)

1. **PR `test:`** — testes automatizados (Mocha + Supertest) cobrindo CT-EP002-US006-01 a 09 (replicando o padrão do PR #36 da US-001).
2. **PR `test:`** — adicionar a coleção Postman oficial da US-006 dentro de `postman/Provus-Finance.postman_collection.json` (replicando o padrão do PR #40).
3. **Implementar US-002** (`GET /api/usuarios/me`) — primeira rota protegida — para finalmente exercitar o `authMiddleware` e fechar US-007 e US-008 funcionalmente.
