### PR TITLE
test: adiciona coleção postman da US-006 (login com JWT)

### DIFF
--- a/postman/Provus-Finance.postman_collection.json
+++ b/postman/Provus-Finance.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Provus Finance — Manual API Tests",
-    "description": "Coleção de testes **manuais e exploratórios** da API do Provus Finance.\n\n## Referências\n- `docs/06-testes/casos-teste-ep-001-usuarios.md`\n- `docs/05-user-stories/ep-001-usuarios.md`\n- `docs/06-testes/estrategia-testes.md`\n\n## Pré-requisitos\n1. API rodando: `cd api && npm start` (porta 3000 por padrão).\n2. Banco de desenvolvimento aplicado: `cd api && npm run db:migrate`.\n3. Para reexecutar a coleção do zero, resetar o banco: `cd api && npm run db:reset`.\n\n## Variáveis\n- `baseUrl` (definida na coleção): `http://localhost:3000`. Pode ser sobrescrita por environment.",
+    "description": "Coleção de testes **manuais e exploratórios** da API do Provus Finance.\n\n## Referências\n- `docs/06-testes/casos-teste-ep-001-usuarios.md`\n- `docs/06-testes/casos-teste-ep-002-autenticacao.md`\n- `docs/05-user-stories/ep-001-usuarios.md`\n- `docs/05-user-stories/ep-002-autenticacao.md`\n- `docs/06-testes/estrategia-testes.md`\n\n## Pré-requisitos\n1. API rodando: `cd api && npm start` (porta 3000 por padrão).\n2. Banco de desenvolvimento aplicado: `cd api && npm run db:migrate`.\n3. Para reexecutar a coleção do zero, resetar o banco: `cd api && npm run db:reset`.\n\n## Dependências entre pastas\n- A US-006 (login) depende do CT-01 da US-001 (cria o usuário `ana.souza@teste.local`). Rode primeiro a US-001 → CT-01 e depois execute a US-006.\n\n## Variáveis\n- `baseUrl` (definida na coleção): `http://localhost:3000`. Pode ser sobrescrita por environment.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -471,6 +471,323 @@
                   ]
                 },
                 "description": "**Caso:** CT-EP001-US001-14\n**US:** US-001\n**Regras:** RU-019\n**Prioridade:** Média\n\n**Pré-condições:**\n- Nenhuma.\n\n**Passos:**\n1. Enviar `nome` composto apenas por dígitos.\n\n**Resultado esperado:**\n- HTTP `400`\n- `erro.detalhes` deve conter item com `campo: nome`"
+              },
+              "response": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "EP-002 — Autenticação",
+      "item": [
+        {
+          "name": "US-006 — Login com JWT (POST /api/auth/login)",
+          "description": "Cenários manuais do endpoint `POST /api/auth/login` cobrindo os 9 casos de teste documentados em `docs/06-testes/casos-teste-ep-002-autenticacao.md` (CT-EP002-US006-01 a CT-EP002-US006-09).\n\n**Ordem de execução:** rode primeiro o CT-01 da US-001 para criar o usuário `ana.souza@teste.local`. Os requests da US-006 reaproveitam essa credencial. Para reexecutar do zero: `cd api && npm run db:reset` e depois US-001 → CT-01 → US-006.\n\n**Dependência entre requests:**\n- Os CTs 01, 03, 05, 07, 08 e 09 dependem do usuário `ana.souza@teste.local` existir (US-001 → CT-01).\n- Os CTs 02, 04 e 06 são independentes.",
+          "item": [
+            {
+              "name": "01 — Login com credenciais válidas",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"ana.souza@teste.local\",\n  \"senha\": \"SenhaForte1\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/auth/login",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "auth",
+                    "login"
+                  ]
+                },
+                "description": "**Caso:** CT-EP002-US006-01\n**US:** US-006\n**Regras:** RU-021, RU-023, RU-024, RU-026, RG-001\n**Prioridade:** Alta\n\n**Pré-condições:**\n- Executar antes o CT-01 da US-001 (cria o usuário `ana.souza@teste.local`).\n\n**Passos:**\n1. Enviar `POST /api/auth/login` com `email` e `senha` corretos.\n\n**Resultado esperado:**\n- HTTP `200`\n- Body com `token` (string JWT) e `usuario` (`{ id, nome, email }`)\n- **Sem** os campos `senha`, `senha_hash` ou `senhaHash`\n\n**Observação:**\n- Para reusar o token em rotas protegidas (após implementação da US-002), copie-o e cole na variável de coleção `tokenAtual`."
+              },
+              "response": []
+            },
+            {
+              "name": "02 — Login com e-mail não cadastrado",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"naoexiste@teste.local\",\n  \"senha\": \"Qualquer1\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/auth/login",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "auth",
+                    "login"
+                  ]
+                },
+                "description": "**Caso:** CT-EP002-US006-02\n**US:** US-006\n**Regras:** RU-022\n**Prioridade:** Alta\n\n**Pré-condições:**\n- E-mail `naoexiste@teste.local` ainda não cadastrado.\n\n**Passos:**\n1. Enviar `POST /api/auth/login` com um e-mail inexistente.\n\n**Resultado esperado:**\n- HTTP `401`\n- `erro.codigo = CREDENCIAIS_INVALIDAS`\n- Mensagem genérica (não revela se o e-mail existe)."
+              },
+              "response": []
+            },
+            {
+              "name": "03 — Login com senha incorreta",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"ana.souza@teste.local\",\n  \"senha\": \"SenhaErrada1\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/auth/login",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "auth",
+                    "login"
+                  ]
+                },
+                "description": "**Caso:** CT-EP002-US006-03\n**US:** US-006\n**Regras:** RU-022, RU-026\n**Prioridade:** Alta\n\n**Pré-condições:**\n- Executar antes o CT-01 da US-001.\n\n**Passos:**\n1. Enviar `POST /api/auth/login` com `email` correto e `senha` errada.\n\n**Resultado esperado:**\n- HTTP `401`\n- `erro.codigo = CREDENCIAIS_INVALIDAS`\n- Resposta **idêntica** à do CT-02 (anti-enumeração — RU-022)."
+              },
+              "response": []
+            },
+            {
+              "name": "04 — Login sem campo email",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"senha\": \"SenhaForte1\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/auth/login",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "auth",
+                    "login"
+                  ]
+                },
+                "description": "**Caso:** CT-EP002-US006-04\n**US:** US-006\n**Regras:** RU-021, RG-014\n**Prioridade:** Alta\n\n**Pré-condições:**\n- Nenhuma.\n\n**Passos:**\n1. Enviar requisição **sem** o campo `email`.\n\n**Resultado esperado:**\n- HTTP `400`\n- `erro.codigo = CAMPO_OBRIGATORIO`\n- `erro.detalhes` deve conter item com `campo: email`."
+              },
+              "response": []
+            },
+            {
+              "name": "05 — Login sem campo senha",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"ana.souza@teste.local\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/auth/login",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "auth",
+                    "login"
+                  ]
+                },
+                "description": "**Caso:** CT-EP002-US006-05\n**US:** US-006\n**Regras:** RU-021, RG-014\n**Prioridade:** Alta\n\n**Pré-condições:**\n- Nenhuma.\n\n**Passos:**\n1. Enviar requisição **sem** o campo `senha`.\n\n**Resultado esperado:**\n- HTTP `400`\n- `erro.codigo = CAMPO_OBRIGATORIO`\n- `erro.detalhes` deve conter item com `campo: senha`."
+              },
+              "response": []
+            },
+            {
+              "name": "06 — Body sem JSON válido",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "isto nao e um json valido",
+                  "options": {
+                    "raw": {
+                      "language": "text"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/auth/login",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "auth",
+                    "login"
+                  ]
+                },
+                "description": "**Caso:** CT-EP002-US006-06\n**US:** US-006\n**Regras:** RG-007\n**Prioridade:** Média\n\n**Pré-condições:**\n- Nenhuma.\n\n**Passos:**\n1. Enviar requisição com header `Content-Type: application/json` e body em formato **inválido** (ex.: texto puro).\n\n**Resultado esperado:**\n- HTTP `400`\n- `erro.codigo = FORMATO_INVALIDO`"
+              },
+              "response": []
+            },
+            {
+              "name": "07 — Inspeção do payload do JWT",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"ana.souza@teste.local\",\n  \"senha\": \"SenhaForte1\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/auth/login",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "auth",
+                    "login"
+                  ]
+                },
+                "description": "**Caso:** CT-EP002-US006-07\n**US:** US-006\n**Regras:** RU-025, RG-013\n**Prioridade:** Alta\n\n**Pré-condições:**\n- Executar antes o CT-01 da US-001.\n\n**Passos:**\n1. Realizar login com sucesso.\n2. Copiar o `token` retornado.\n3. Colar em [jwt.io](https://jwt.io) (aba Decoded → Payload).\n\n**Resultado esperado:**\n- Payload contém `sub`, `email`, `iat`, `exp`.\n- `sub` igual ao `id` do usuário.\n- `email` em minúsculas.\n- `exp - iat ≈ 86400` segundos (24h)."
+              },
+              "response": []
+            },
+            {
+              "name": "08 — Login case-insensitive no e-mail",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"ANA.SOUZA@TESTE.LOCAL\",\n  \"senha\": \"SenhaForte1\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/auth/login",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "auth",
+                    "login"
+                  ]
+                },
+                "description": "**Caso:** CT-EP002-US006-08\n**US:** US-006\n**Regras:** RU-010, RG-020\n**Prioridade:** Média\n\n**Pré-condições:**\n- Executar antes o CT-01 da US-001 (cadastro com e-mail em minúsculas).\n\n**Passos:**\n1. Enviar requisição com o mesmo e-mail em **caixa alta**.\n\n**Resultado esperado:**\n- HTTP `200`\n- `usuario.email` retornado em minúsculas.\n- Decodificando o token (jwt.io), o campo `email` do payload está em minúsculas."
+              },
+              "response": []
+            },
+            {
+              "name": "09 — Múltiplas sessões simultâneas",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"email\": \"ana.souza@teste.local\",\n  \"senha\": \"SenhaForte1\"\n}",
+                  "options": {
+                    "raw": {
+                      "language": "json"
+                    }
+                  }
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/api/auth/login",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "auth",
+                    "login"
+                  ]
+                },
+                "description": "**Caso:** CT-EP002-US006-09\n**US:** US-006\n**Regras:** RU-027\n**Prioridade:** Média\n\n**Pré-condições:**\n- Executar antes o CT-01 da US-001.\n\n**Passos:**\n1. Executar este request **duas vezes** com pequeno intervalo (~1s).\n2. Comparar visualmente os dois tokens retornados.\n\n**Resultado esperado:**\n- HTTP `200` em ambas as execuções.\n- Os dois tokens são **diferentes** (`iat` distintos).\n- Decodificando ambos (jwt.io), o `sub` é igual em ambos (mesmo usuário).\n- Login mais recente **não invalida** o anterior (validação completa virá após uma rota protegida real ser implementada — provavelmente no PR da US-002)."
               },
               "response": []
             }


### PR DESCRIPTION
## Resumo

Adiciona a pasta `EP-002 → US-006` à coleção Postman existente, fechando o último item da Definition of Done da US-006 (login com JWT). A coleção agora cobre **23 cenários manuais** (14 da US-001 + 9 da US-006).

## O que entra

Mudança cirúrgica em **um único arquivo**:

| Arquivo | Status | Linhas |
|---|:---:|:---:|
| `postman/Provus-Finance.postman_collection.json` | modificado (+318 / -1) | 489 → 806 |

### Estrutura final da coleção

```
📁 EP-001 — Usuários                                    (intacto)
   📁 US-001 — Cadastrar usuário (POST /api/usuarios)
      • 01 → 14  (14 cenários existentes, sem alteração)

📁 EP-002 — Autenticação                                (NOVO)
   📁 US-006 — Login com JWT (POST /api/auth/login)
      • 01 — Login com credenciais válidas
      • 02 — Login com e-mail não cadastrado
      • 03 — Login com senha incorreta
      • 04 — Login sem campo email
      • 05 — Login sem campo senha
      • 06 — Body sem JSON válido
      • 07 — Inspeção do payload do JWT
      • 08 — Login case-insensitive no e-mail
      • 09 — Múltiplas sessões simultâneas
```

## Cobertura por request — espelhamento 1:1 do documento oficial

Numeração e rastreabilidade idênticas aos `CT-EP002-US006-XX` em `casos-teste-ep-002-autenticacao.md`.

| Request | Caso | Body | Esperado |
|:---:|---|---|---|
| 01 | CT-EP002-US006-01 | `{ email, senha }` válidos | `200` + token + usuario |
| 02 | CT-EP002-US006-02 | email não cadastrado | `401 CREDENCIAIS_INVALIDAS` |
| 03 | CT-EP002-US006-03 | email correto, senha errada | `401 CREDENCIAIS_INVALIDAS` (idêntico ao 02 — RU-022) |
| 04 | CT-EP002-US006-04 | só `senha` | `400 CAMPO_OBRIGATORIO` (campo: email) |
| 05 | CT-EP002-US006-05 | só `email` | `400 CAMPO_OBRIGATORIO` (campo: senha) |
| 06 | CT-EP002-US006-06 | body texto puro com Content-Type JSON | `400 FORMATO_INVALIDO` |
| 07 | CT-EP002-US006-07 | igual ao 01 | `200` — instrução para colar token em [jwt.io](https://jwt.io) e validar payload |
| 08 | CT-EP002-US006-08 | email em CAIXA ALTA | `200` + email lowercase |
| 09 | CT-EP002-US006-09 | igual ao 01 | `200` ×2 — instrução para rodar duas vezes e comparar tokens |

## Decisões de design

- **Reuso de credenciais** — os requests da US-006 usam `ana.souza@teste.local / SenhaForte1`, mesmo usuário criado pelo `CT-01` da US-001. Cria uma narrativa contínua para o QA exploratório (cadastrar → logar) e evita duplicação de fixtures.
- **Coleção segue 100% manual** (opção A do plano) — sem `pre-request scripts`, sem `test scripts`, sem variáveis novas além de `baseUrl`. Mesmo padrão dos 14 cenários existentes da US-001. Quando a US-002 (rota protegida) chegar, aí sim adicionamos `pm.collectionVariables.set('tokenAtual', ...)` em PR específico.
- **CT-06 com body em modo `text`** + `Content-Type: application/json` — exercita o branch `entity.parse.failed` do `error.middleware.js`, exatamente como o teste Mocha equivalente do PR #45.
- **CT-07 e CT-09 com instruções para jwt.io** — coleção é manual, sem asserções automáticas. As validações de payload do JWT (decodificação) ficam por conta do QA usando ferramenta externa, exatamente como em testes exploratórios reais.
- **Dependências entre requests documentadas** — o `description` da pasta US-006 lista quais CTs dependem do CT-01 da US-001 (01, 03, 05, 07, 08, 09) e quais são independentes (02, 04, 06).

## Reuso vs. novidade

| Item | Reuso da US-001 | Novidade |
|---|:---:|:---:|
| Schema 2.1.0 | ✓ | — |
| Padrão de `name` (`XX — Descrição`) | ✓ | — |
| Estrutura do `description` (Caso/US/Regras/Prioridade/...) | ✓ | — |
| Variável `baseUrl` | ✓ | — |
| URL absoluta | ✓ | — |
| 9 requests novos | — | ✓ |
| Pasta raiz `EP-002` | — | ✓ |
| Referências do EP-002 no `info.description` | — | ✓ |

## Rastreabilidade

- **User Story:** `US-006` (`docs/05-user-stories/ep-002-autenticacao.md`)
- **Casos de teste:** `CT-EP002-US006-01` a `CT-EP002-US006-09` (`docs/06-testes/casos-teste-ep-002-autenticacao.md`)
- **Implementação:** PR [#44](../pull/44)
- **Testes Mocha automatizados:** PR [#45](../pull/45)
- **Coleção Postman (este PR):** fecha o último item da DoD

## Validação realizada antes do commit

| Item | Resultado |
|---|:---:|
| `JSON.parse` da coleção | ✓ válido |
| Schema 2.1.0 preservado | ✓ |
| 14 requests da US-001 intactos | ✓ |
| 9 requests da US-006 com URL `/api/auth/login` | ✓ |
| Variáveis de coleção (`baseUrl` apenas) | ✓ |
| Sem scripts (`pre-request` / `test`) | ✓ |
| Diff: +318 / -1 (apenas substituição do `info.description`) | ✓ |
| Rastro de IA na coleção | ausente ✓ |

## Definition of Done da US-006 — completa

| Etapa | PR | Estado |
|---|:---:|:---:|
| Implementação (`feat:`) | [#44](../pull/44) | ✅ |
| Testes Mocha automatizados (`test:`) | [#45](../pull/45) | ✅ |
| Coleção Postman manual (`test:`) | **este PR** | ✅ |

## Próximos passos depois deste PR

1. Implementação da **US-007 / US-008** (middleware `auth.middleware.js` já está pronto desde o setup inicial — falta apenas uma rota protegida real exercitá-lo).
2. Caminho natural: implementar **US-002** (`GET /api/usuarios/me`), que ao mesmo tempo:
   - É a primeira rota protegida do projeto (US-007 ganha cobertura de teste real).
   - Permite reforçar o `CT-EP002-US006-09` (múltiplas sessões), substituindo a cobertura PARCIAL atual por validação contra rota protegida.
