### PR TITLE
feat: implementa US-002 — consultar próprio perfil (GET /api/usuarios/me)

### DIFF
--- a/api/src/controllers/usuario.controller.js
+++ b/api/src/controllers/usuario.controller.js
@@ -16,6 +16,21 @@ export async function criar(req, res, next) {
   }
 }
 
+/**
+ * GET /api/usuarios/me — consulta próprio perfil autenticado (US-002).
+ *
+ * Espera middleware `authMiddleware` (req.usuario.{ id, email }).
+ */
+export function obterPerfil(req, res, next) {
+  try {
+    const dados = usuarioService.obterPerfil(req.usuario.id);
+    res.status(200).json(dados);
+  } catch (erro) {
+    next(erro);
+  }
+}
+
 export default {
   criar,
+  obterPerfil,
 };

--- a/api/src/routes/usuario.routes.js
+++ b/api/src/routes/usuario.routes.js
@@ -1,7 +1,48 @@
 import { Router } from 'express';
 import usuarioController from '../controllers/usuario.controller.js';
+import { authMiddleware } from '../middlewares/auth.middleware.js';
 
 const router = Router();
+
+/**
+ * @swagger
+ * /api/usuarios/me:
+ *   get:
+ *     tags: [Usuários]
+ *     summary: Consulta próprio perfil autenticado
+ *     description: |
+ *       Devolve dados do usuário autenticado (sem dados sensíveis).
+ *       Requer `Authorization: Bearer <token>` obtido via `POST /api/auth/login`.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Perfil público do usuário
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 id:
+ *                   type: integer
+ *                   example: 1
+ *                 nome:
+ *                   type: string
+ *                 email:
+ *                   type: string
+ *                   format: email
+ *                 criadoEm:
+ *                   type: string
+ *                   format: date-time
+ *                 atualizadoEm:
+ *                   type: string
+ *                   format: date-time
+ *       401:
+ *         description: Token ausente, inválido ou expirado
+ *       404:
+ *         description: Usuário associado ao token não existe mais
+ */
+router.get('/me', authMiddleware, usuarioController.obterPerfil);
 
 /**
  * @swagger

--- a/api/src/services/usuario.service.js
+++ b/api/src/services/usuario.service.js
@@ -176,6 +176,27 @@ export async function criar(dados) {
   return formatarResposta(usuarioCriado);
 }
 
+/**
+ * Retorna o perfil público do usuário (GET /api/usuarios/me).
+ *
+ * @param {number} usuarioId — id vindos do payload JWT (`sub`)
+ * @returns {Object} `{ id, nome, email, criadoEm, atualizadoEm }` — sem campos sensíveis
+ */
+export function obterPerfil(usuarioId) {
+  const usuario = usuarioRepository.buscarPorId(usuarioId);
+
+  if (!usuario) {
+    throw new AppError(
+      'USUARIO_NAO_ENCONTRADO',
+      'Usuário não encontrado.',
+      404
+    );
+  }
+
+  return formatarResposta(usuario);
+}
+
 export default {
   criar,
+  obterPerfil,
 };

--- a/api/tests/api/usuarios/perfil.test.js
+++ b/api/tests/api/usuarios/perfil.test.js
@@ -1,0 +1,85 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import app from '../../../src/app.js';
+import { limparBanco } from '../../helpers/database.helper.js';
+import { gerarJwtExpiradoAssinado } from '../../helpers/jwt.helper.js';
+import { criarUsuarioParaLogin } from '../../fixtures/auth.fixtures.js';
+
+describe('GET /api/usuarios/me — Consultar próprio perfil (US-002)', () => {
+  beforeEach(() => {
+    limparBanco();
+  });
+
+  describe('Consulta autorizada', () => {
+    it('[CT-EP001-US002-01][US-002][RU-028,RU-029,RG-008] deve retornar 200 com dados do próprio usuário sem campos sensíveis', async () => {
+      const { usuario, credenciais } = await criarUsuarioParaLogin();
+
+      const login = await request(app).post('/api/auth/login').send(credenciais);
+      expect(login.status).to.equal(200);
+      const { token } = login.body;
+
+      const response = await request(app)
+        .get('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body.id).to.equal(usuario.id);
+      expect(response.body.nome).to.equal(usuario.nome);
+      expect(response.body.email).to.equal(credenciais.email.trim().toLowerCase());
+      expect(response.body).to.have.property('criadoEm');
+      expect(response.body).to.have.property('atualizadoEm');
+      expect(response.body).to.not.have.property('senha');
+      expect(response.body).to.not.have.property('senha_hash');
+      expect(response.body).to.not.have.property('senhaHash');
+    });
+
+    it('[CT-EP001-US002-05][US-002][RG-004] resposta não deve expor senha nem senha_hash', async () => {
+      const { credenciais } = await criarUsuarioParaLogin();
+
+      const login = await request(app).post('/api/auth/login').send(credenciais);
+      const { token } = login.body;
+
+      const response = await request(app)
+        .get('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).to.equal(200);
+      expect(response.body).to.not.have.any.keys('senha', 'senha_hash', 'senhaHash');
+    });
+  });
+
+  describe('Token ausente ou inválido', () => {
+    it('[CT-EP001-US002-02][US-002][RG-009] deve retornar 401 TOKEN_AUSENTE sem header Authorization', async () => {
+      const response = await request(app).get('/api/usuarios/me');
+
+      expect(response.status).to.equal(401);
+      expect(response.body.erro.codigo).to.equal('TOKEN_AUSENTE');
+    });
+
+    it('[CT-EP001-US002-03][US-002][RG-010] deve retornar 401 TOKEN_INVALIDO com token inválido', async () => {
+      const response = await request(app)
+        .get('/api/usuarios/me')
+        .set('Authorization', 'Bearer formato-invalido-nao-jwt-real');
+
+      expect(response.status).to.equal(401);
+      expect(response.body.erro.codigo).to.equal('TOKEN_INVALIDO');
+    });
+
+    it('[CT-EP001-US002-04][US-002][RG-011] deve retornar 401 TOKEN_EXPIRADO com token expirado', async () => {
+      const { usuario } = await criarUsuarioParaLogin();
+      expect(usuario.id).to.be.a('number');
+
+      const tokenExpirado = gerarJwtExpiradoAssinado({
+        sub: usuario.id,
+        email: usuario.email,
+      });
+
+      const response = await request(app)
+        .get('/api/usuarios/me')
+        .set('Authorization', `Bearer ${tokenExpirado}`);
+
+      expect(response.status).to.equal(401);
+      expect(response.body.erro.codigo).to.equal('TOKEN_EXPIRADO');
+    });
+  });
+});

--- a/api/tests/helpers/jwt.helper.js
+++ b/api/tests/helpers/jwt.helper.js
@@ -1,6 +1,23 @@
 import jwt from 'jsonwebtoken';
 
 /**
+ * JWT assinado com `exp` já no passado — útil apenas em testes (CT token expirado).
+ * Usa JWT_SECRET do ambiente como a API real.
+ * Chame só depois de importar `app` (carrega dotenv via `src/utils/jwt.js`).
+ *
+ * @param {{ sub: number, email: string }} usuario
+ * @returns {string} Token que `validarToken()` rejeitará como expirado
+ */
+export function gerarJwtExpiradoAssinado({ sub, email }) {
+  const SECRET = process.env.JWT_SECRET;
+  if (!SECRET) {
+    throw new Error('JWT_SECRET obrigatório nos testes (api/.env).');
+  }
+  const exp = Math.floor(Date.now() / 1000) - 600;
+  return jwt.sign({ sub, email, exp }, SECRET);
+}
+
+/**
  * Decodifica o payload de um JWT SEM validar assinatura nem expiração.
  *
  * Uso EXCLUSIVO em testes — permite inspecionar o conteúdo do token
@@ -17,5 +34,6 @@ export function decodificarPayload(token) {
 }
 
 export default {
+  gerarJwtExpiradoAssinado,
   decodificarPayload,
 };

--- a/postman/Provus-Finance.postman_collection.json
+++ b/postman/Provus-Finance.postman_collection.json
@@ -1,7 +1,7 @@
 {
   "info": {
     "name": "Provus Finance — Manual API Tests",
-    "description": "Coleção de testes **manuais e exploratórios** da API do Provus Finance.\n\n## Referências\n- `docs/06-testes/casos-teste-ep-001-usuarios.md`\n- `docs/06-testes/casos-teste-ep-002-autenticacao.md`\n- `docs/05-user-stories/ep-001-usuarios.md`\n- `docs/05-user-stories/ep-002-autenticacao.md`\n- `docs/06-testes/estrategia-testes.md`\n\n## Pré-requisitos\n1. API rodando: `cd api && npm start` (porta 3000 por padrão).\n2. Banco de desenvolvimento aplicado: `cd api && npm run db:migrate`.\n3. Para reexecutar a coleção do zero, resetar o banco: `cd api && npm run db:reset`.\n\n## Dependências entre pastas\n- A US-006 (login) depende do CT-01 da US-001 (cria o usuário `ana.souza@teste.local`). Rode primeiro a US-001 → CT-01 e depois execute a US-006.\n\n## Variáveis\n- `baseUrl` (definida na coleção): `http://localhost:3000`. Pode ser sobrescrita por environment.",
+    "description": "Coleção de testes **manuais e exploratórios** da API do Provus Finance.\n\n## Referências\n- `docs/06-testes/casos-teste-ep-001-usuarios.md`\n- `docs/06-testes/casos-teste-ep-002-autenticacao.md`\n- `docs/05-user-stories/ep-001-usuarios.md`\n- `docs/05-user-stories/ep-002-autenticacao.md`\n- `docs/06-testes/estrategia-testes.md`\n\n## Pré-requisitos\n1. API rodando: `cd api && npm start` (porta 3000 por padrão).\n2. Banco de desenvolvimento aplicado: `cd api && npm run db:migrate`.\n3. Para reexecutar a coleção do zero, resetar o banco: `cd api && npm run db:reset`.\n\n## Dependências entre pastas\n- A US-006 (login) depende do CT-01 da US-001 (cria o usuário `ana.souza@teste.local`). Rode primeiro a US-001 → CT-01 e depois execute a US-006.\n\n## Variáveis\n- `baseUrl` (definida na coleção): `http://localhost:3000`. Pode ser sobrescrita por environment.\n\n**US-002 — GET /api/usuarios/me**\nCadastro + login antes; JWT em `tokenAtual` / `tokenJWTExpirado` conforme pasta EP-001 → US-002.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -475,6 +475,132 @@
               "response": []
             }
           ]
+        },
+        {
+          "name": "US-002 — Consultar próprio perfil (GET /api/usuarios/me)",
+          "description": "Cenários manuais do endpoint `GET /api/usuarios/me`, espelho dos casos CT-EP001-US002-01 a CT-EP001-US002-05 em `docs/06-testes/casos-teste-ep-001-usuarios.md`.\n\n**Fluxo habitual:** primeiro `US-001` → CT-01 (cria `ana.souza@teste.local`), depois `US-006` → CT-01 (login); copiar o JWT retornado para a variável de coleção `tokenAtual`.\n\n**CT-04 (token expirado):** preencher `tokenJWTExpirado` conforme comando na descrição do request **04**.\n\nSem scripts de teste nos requests — apenas exploração manual.",
+          "item": [
+            {
+              "name": "01 — Consulta com token válido",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{tokenAtual}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/usuarios/me",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "usuarios",
+                    "me"
+                  ]
+                },
+                "description": "**Caso:** CT-EP001-US002-01\n**US:** US-002\n**Regras:** RU-028, RU-029, RG-008\n\n**Passos:**\n1. Preencher `tokenAtual` (login US-006 ou `POST /api/auth/login`).\n2. `GET /api/usuarios/me`.\n\n**Resultado esperado:** HTTP `200` — `id`, `nome`, `email`, `criadoEm`, `atualizadoEm` — sem `senha` / `senha_hash`."
+              },
+              "response": []
+            },
+            {
+              "name": "02 — Consulta sem token",
+              "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                  "raw": "{{baseUrl}}/api/usuarios/me",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "usuarios",
+                    "me"
+                  ]
+                },
+                "description": "**Caso:** CT-EP001-US002-02\n**US:** US-002\n**Regras:** RG-009\n\n**Resultado esperado:** HTTP `401`, `TOKEN_AUSENTE`."
+              },
+              "response": []
+            },
+            {
+              "name": "03 — Consulta com token inválido",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer formato-invalido-nao-jwt"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/usuarios/me",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "usuarios",
+                    "me"
+                  ]
+                },
+                "description": "**Caso:** CT-EP001-US002-03\n**US:** US-002\n**Regras:** RG-010\n\n**Resultado esperado:** HTTP `401`, `TOKEN_INVALIDO`."
+              },
+              "response": []
+            },
+            {
+              "name": "04 — Consulta com token expirado",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{tokenJWTExpirado}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/usuarios/me",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "usuarios",
+                    "me"
+                  ]
+                },
+                "description": "**Caso:** CT-EP001-US002-04\n**US:** US-002\n**Regras:** RG-011\n\n**Gerar JWT expirado (pasta `api/`, `JWT_SECRET` no `.env`):**\n```bash\nnode --input-type=module -e \"import jwt from 'jsonwebtoken'; import dotenv from 'dotenv'; dotenv.config(); const s=process.env.JWT_SECRET; const t=jwt.sign({sub:1,email:'ana.souza@teste.local',exp:Math.floor(Date.now()/1000)-600},s); console.log(t);\"\n```\nColar a saída em `tokenJWTExpirado` (ajuste `sub`/`email` ao utilizador real).\n\n**Resultado esperado:** HTTP `401`, `TOKEN_EXPIRADO`."
+              },
+              "response": []
+            },
+            {
+              "name": "05 — Verificar não exposição de dados sensíveis",
+              "request": {
+                "method": "GET",
+                "header": [
+                  {
+                    "key": "Authorization",
+                    "value": "Bearer {{tokenAtual}}"
+                  }
+                ],
+                "url": {
+                  "raw": "{{baseUrl}}/api/usuarios/me",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "api",
+                    "usuarios",
+                    "me"
+                  ]
+                },
+                "description": "**Caso:** CT-EP001-US002-05\n**US:** US-002\n**Regras:** RG-004\n\nMesmo token que **01**. Verificar JSON sem `senha`, `senha_hash`, `senhaHash`."
+              },
+              "response": []
+            }
+          ]
         }
       ]
     },
@@ -801,6 +927,18 @@
       "key": "baseUrl",
       "value": "http://localhost:3000",
       "type": "string"
+    },
+    {
+      "key": "tokenAtual",
+      "value": "",
+      "type": "string",
+      "description": "JWT após `POST /api/auth/login`."
+    },
+    {
+      "key": "tokenJWTExpirado",
+      "value": "",
+      "type": "string",
+      "description": "JWT expirado — só CT-04 (ver request 04)."
     }
   ]
 }


### PR DESCRIPTION
## Resumo

Implementação da **US-002** — `GET /api/usuarios/me` — conforme [`docs/06-testes/casos-teste-ep-001-usuarios.md`](docs/06-testes/casos-teste-ep-001-usuarios.md) (`CT-EP001-US002-01` a `05`).

## O que entra

| Área | Conteúdo |
|------|-----------|
| Rotas | `GET /api/usuarios/me` — `authMiddleware` → controller → service → repositório |
| Swagger | Endpoint documentado sob tag **Usuários** |
| Testes | `api/tests/api/usuarios/perfil.test.js` — 5 cenários espelham os CT oficiais |
| Helper testes | `gerarJwtExpiradoAssinado` em `jwt.helper.js` (CT-04 / RG-011) |
| Postman | Pasta **EP-001 → US-002** (5 GET), variáveis de coleção `tokenAtual` e `tokenJWTExpirado` |

## Cobertura Mocha (1:1)

| CT | Resultado esperado |
|----|-------------------|
| CT-EP001-US002-01 | 200 — perfil com JWT válido; sem dados sensíveis |
| CT-EP001-US002-02 | 401 `TOKEN_AUSENTE` |
| CT-EP001-US002-03 | 401 `TOKEN_INVALIDO` |
| CT-EP001-US002-04 | 401 `TOKEN_EXPIRADO` |
| CT-EP001-US002-05 | Resposta sem `senha` / `senha_hash` |

## Validação

`cd api && npm run test:setup && npm test` — **29 passing** esperado.

## Rastreabilidade

- **US:** US-002 (`docs/05-user-stories/ep-001-usuarios.md`)
- **Regras:** RU-028, RU-029, RG-004, RG-008 a RG-011 conforme cada CT
