### PR TITLE
feat: implementa exclusão de conta (US-005)

### DIFF
--- a/api/src/controllers/usuario.controller.js
+++ b/api/src/controllers/usuario.controller.js
@@ -54,9 +54,26 @@ export async function alterarSenha(req, res, next) {
   }
 }
 
+/**
+ * DELETE /api/usuarios/me
+ * Exclui a conta do usuário autenticado.
+ */
+export async function excluirConta(req, res, next) {
+  try {
+    const usuarioId = req.usuario.id;
+    await usuarioService.excluirConta(usuarioId, req.body);
+
+    // 204 No Content — sucesso sem body
+    res.status(204).send();
+  } catch (erro) {
+    next(erro);
+  }
+}
+
 export default {
   criar,
   obterPerfil,
   atualizarPerfil,
   alterarSenha,
+  excluirConta
 };

--- a/api/src/repositories/usuario.repository.js
+++ b/api/src/repositories/usuario.repository.js
@@ -105,6 +105,18 @@ export function atualizarSenhaHash(id, senhaHash) {
   return buscarPorId(id);
 }
 
+/**
+ * Exclui um usuário pelo ID.
+ *
+ * @param {number} id
+ * @returns {boolean} true se excluiu, false se ID não existia
+ */
+export function excluir(id) {
+  const stmt = db.prepare('DELETE FROM usuarios WHERE id = ?');
+  const resultado = stmt.run(id);
+  return resultado.changes > 0;
+}
+
 export default {
   inserir,
   buscarPorId,
@@ -112,4 +124,5 @@ export default {
   emailExiste,
   atualizarDados,
   atualizarSenhaHash,
+  excluir,
 };

--- a/api/src/routes/usuario.routes.js
+++ b/api/src/routes/usuario.routes.js
@@ -171,4 +171,43 @@ router.put('/me/senha', authMiddleware, usuarioController.alterarSenha);
  */
 router.post('/', usuarioController.criar);
 
+/**
+ * @swagger
+ * /api/usuarios/me:
+ *   delete:
+ *     tags: [Usuários]
+ *     summary: Exclui a conta do usuário autenticado
+ *     description: |
+ *       Remove permanentemente a conta do usuário autenticado.
+ *       Exige confirmação de senha no body por segurança.
+ *
+ *       **Após exclusão:**
+ *       - Token JWT antigo torna-se inválido (usuário não existe mais)
+ *       - E-mail volta a ficar disponível para novo cadastro
+ *       - Operação é atômica (transação única)
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [senha]
+ *             properties:
+ *               senha:
+ *                 type: string
+ *                 format: password
+ *                 description: Senha atual do usuário (confirmação obrigatória)
+ *                 example: "SenhaForte1"
+ *     responses:
+ *       204:
+ *         description: Conta excluída com sucesso (sem body)
+ *       400:
+ *         description: Senha de confirmação ausente (CAMPO_OBRIGATORIO)
+ *       401:
+ *         description: Token ausente/inválido OU senha incorreta (CREDENCIAIS_INVALIDAS)
+ */
+router.delete('/me', authMiddleware, usuarioController.excluirConta);
+
 export default router;

--- a/api/src/services/usuario.service.js
+++ b/api/src/services/usuario.service.js
@@ -339,9 +339,81 @@ export async function alterarSenha(usuarioId, body = {}) {
   };
 }
 
+/**
+ * DELETE /api/usuarios/me — exclui a conta do usuário autenticado (US-005).
+ *
+ * Exige confirmação de senha no body por segurança (RU-044).
+ *
+ * Após exclusão:
+ * - Token JWT antigo continua tecnicamente "válido" (assinado),
+ *   mas qualquer requisição autenticada vai retornar 404 USUARIO_NAO_ENCONTRADO
+ *   ao tentar carregar o usuário pelo `sub` do token (RU-048).
+ * - O e-mail volta a ficar disponível para novo cadastro (RU-049).
+ *
+ * Atomicidade: a exclusão é executada em transação única (RU-046, RG-038).
+ * Quando houver tabelas relacionadas (contas, categorias, transações),
+ * elas serão removidas em cascata via foreign keys.
+ *
+ * @param {number} usuarioId
+ * @param {{ senha?: string }} body
+ * @returns {Promise<void>} Não retorna body — controller envia 204
+ * @throws {AppError} 400 CAMPO_OBRIGATORIO — senha ausente
+ * @throws {AppError} 401 CREDENCIAIS_INVALIDAS — senha incorreta
+ * @throws {AppError} 404 USUARIO_NAO_ENCONTRADO — usuário do token não existe
+ */
+export async function excluirConta(usuarioId, body = {}) {
+  const temSenha = Object.prototype.hasOwnProperty.call(body, 'senha');
+
+  if (!temSenha) {
+    throw new AppError(
+      'CAMPO_OBRIGATORIO',
+      'Senha de confirmação é obrigatória.',
+      400,
+      [{ campo: 'senha', problema: 'Senha é obrigatória.' }]
+    );
+  }
+
+  const senha = body.senha;
+
+  if (typeof senha !== 'string' || senha.length === 0) {
+    throw new AppError(
+      'CAMPO_OBRIGATORIO',
+      'Senha de confirmação é obrigatória.',
+      400,
+      [{ campo: 'senha', problema: 'Senha é obrigatória.' }]
+    );
+  }
+
+  const usuario = usuarioRepository.buscarPorId(usuarioId);
+
+  if (!usuario) {
+    throw new AppError('USUARIO_NAO_ENCONTRADO', 'Usuário não encontrado.', 404);
+  }
+
+  const senhaConfere = await compararHash(senha, usuario.senha_hash);
+
+  if (!senhaConfere) {
+    throw new AppError(
+      'CREDENCIAIS_INVALIDAS',
+      'Senha incorreta.',
+      401
+    );
+  }
+
+  // Exclusão atômica.
+  // SQLite com PRAGMA foreign_keys=ON cuida da cascata quando houver tabelas filhas.
+  const removido = usuarioRepository.excluir(usuarioId);
+
+  if (!removido) {
+    // Race condition extrema (usuário sumiu entre buscar e excluir)
+    throw new AppError('USUARIO_NAO_ENCONTRADO', 'Usuário não encontrado.', 404);
+  }
+}
+
 export default {
   criar,
   obterPerfil,
   atualizarPerfil,
   alterarSenha,
+  excluirConta,
 };

--- a/api/tests/api/usuarios/excluir-conta.test.js
+++ b/api/tests/api/usuarios/excluir-conta.test.js
@@ -1,0 +1,221 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import app from '../../../src/app.js';
+import { limparBanco } from '../../helpers/database.helper.js';
+import { criarUsuarioParaLogin } from '../../fixtures/auth.fixtures.js';
+import { gerarUsuarioValido } from '../../fixtures/usuarios.fixtures.js';
+
+describe('DELETE /api/usuarios/me — Excluir própria conta (US-005)', () => {
+  beforeEach(() => {
+    limparBanco();
+  });
+
+  // ==========================================================
+  // Helper local: cadastra + faz login e devolve { token, usuario, credenciais }
+  // ==========================================================
+  async function logarComUsuarioCadastrado() {
+    const { usuario, credenciais } = await criarUsuarioParaLogin();
+    const login = await request(app).post('/api/auth/login').send(credenciais);
+    expect(login.status).to.equal(200);
+    return { token: login.body.token, usuario, credenciais };
+  }
+
+  // ==========================================================
+  // CT-EP001-US005-01 — Exclusão com senha correta
+  // ==========================================================
+  describe('Exclusão com senha correta', () => {
+    it('[CT-EP001-US005-01][US-005][RU-043,RU-044,RU-047] deve retornar 204 sem body quando senha confere', async () => {
+      const { token, credenciais } = await logarComUsuarioCadastrado();
+
+      const response = await request(app)
+        .delete('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ senha: credenciais.senha });
+
+      expect(response.status).to.equal(204);
+      // 204 não tem body — supertest devolve objeto vazio
+      expect(response.body).to.deep.equal({});
+    });
+  });
+
+  // ==========================================================
+  // CT-EP001-US005-02 — Exclusão com senha incorreta
+  // ==========================================================
+  describe('Exclusão com senha incorreta', () => {
+    it('[CT-EP001-US005-02][US-005][RU-044] deve retornar 401 CREDENCIAIS_INVALIDAS', async () => {
+      const { token } = await logarComUsuarioCadastrado();
+
+      const response = await request(app)
+        .delete('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ senha: 'SenhaErrada123' });
+
+      expect(response.status).to.equal(401);
+      expect(response.body.erro.codigo).to.equal('CREDENCIAIS_INVALIDAS');
+    });
+  });
+
+  // ==========================================================
+  // CT-EP001-US005-03 — Exclusão sem senha de confirmação
+  // ==========================================================
+  describe('Exclusão sem senha de confirmação', () => {
+    it('[CT-EP001-US005-03][US-005][RU-044,RG-014] deve retornar 400 CAMPO_OBRIGATORIO sem campo senha', async () => {
+      const { token } = await logarComUsuarioCadastrado();
+
+      const response = await request(app)
+        .delete('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({});
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.codigo).to.equal('CAMPO_OBRIGATORIO');
+      expect(response.body.erro.detalhes).to.be.an('array');
+      expect(response.body.erro.detalhes.some((d) => d.campo === 'senha')).to.be.true;
+    });
+
+    it('[CT-EP001-US005-03][US-005][RU-044,RG-014] deve retornar 400 CAMPO_OBRIGATORIO com senha vazia', async () => {
+      const { token } = await logarComUsuarioCadastrado();
+
+      const response = await request(app)
+        .delete('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ senha: '' });
+
+      expect(response.status).to.equal(400);
+      expect(response.body.erro.codigo).to.equal('CAMPO_OBRIGATORIO');
+    });
+  });
+
+  // ==========================================================
+  // CT-EP001-US005-04 — Token antigo torna-se inválido após exclusão
+  // ==========================================================
+  describe('Token após exclusão', () => {
+    it('[CT-EP001-US005-04][US-005][RU-048] token antigo retorna 404 ao consultar perfil após exclusão', async () => {
+      const { token, credenciais } = await logarComUsuarioCadastrado();
+
+      // Exclui
+      const exclusao = await request(app)
+        .delete('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ senha: credenciais.senha });
+      expect(exclusao.status).to.equal(204);
+
+      // Tenta usar o mesmo token em rota autenticada
+      const consulta = await request(app)
+        .get('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(consulta.status).to.equal(404);
+      expect(consulta.body.erro.codigo).to.equal('USUARIO_NAO_ENCONTRADO');
+    });
+  });
+
+  // ==========================================================
+  // CT-EP001-US005-05 — Reuso do e-mail após exclusão
+  // ==========================================================
+  describe('Reuso do e-mail após exclusão', () => {
+    it('[CT-EP001-US005-05][US-005][RU-049] e-mail volta a ficar disponível para novo cadastro', async () => {
+      const { token, credenciais } = await logarComUsuarioCadastrado();
+
+      // Exclui o usuário
+      const exclusao = await request(app)
+        .delete('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ senha: credenciais.senha });
+      expect(exclusao.status).to.equal(204);
+
+      // Tenta cadastrar novo usuário com o mesmo e-mail
+      const novoCadastro = await request(app)
+        .post('/api/usuarios')
+        .send({
+          nome: 'Outro Usuario',
+          email: credenciais.email,
+          senha: 'OutraSenha456',
+        });
+
+      expect(novoCadastro.status).to.equal(201);
+      expect(novoCadastro.body.email).to.equal(credenciais.email);
+    });
+  });
+
+  // ==========================================================
+  // CT-EP001-US005-06 — Exclusão remove o registro do banco
+  //
+  // Nota: cobertura de cascata real será adicionada quando
+  //       existirem tabelas filhas (contas, transações, etc.).
+  //       Por enquanto validamos que o usuário some do banco.
+  // ==========================================================
+  describe('Remoção efetiva do banco', () => {
+    it('[CT-EP001-US005-06][US-005][RU-045,RT-071] usuário não deve mais ser encontrado após exclusão', async () => {
+      const { token, credenciais } = await logarComUsuarioCadastrado();
+
+      // Exclui
+      await request(app)
+        .delete('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ senha: credenciais.senha });
+
+      // Login com mesmas credenciais já não funciona
+      const loginAposExclusao = await request(app)
+        .post('/api/auth/login')
+        .send(credenciais);
+
+      expect(loginAposExclusao.status).to.equal(401);
+      expect(loginAposExclusao.body.erro.codigo).to.equal('CREDENCIAIS_INVALIDAS');
+    });
+  });
+
+  // ==========================================================
+  // CT-EP001-US005-07 — Atomicidade
+  //
+  // Por enquanto sem tabelas relacionadas. Validamos que ou tudo
+  // dá certo (204 + sumiço do registro) ou nada acontece.
+  // Quando houver contas/transações, este teste será expandido
+  // para forçar falhas intermediárias e provar rollback.
+  // ==========================================================
+  describe('Atomicidade da exclusão', () => {
+    it('[CT-EP001-US005-07][US-005][RU-046,RG-038] exclusão é tudo-ou-nada (204 + registro removido)', async () => {
+      const { token, credenciais } = await logarComUsuarioCadastrado();
+
+      const exclusao = await request(app)
+        .delete('/api/usuarios/me')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ senha: credenciais.senha });
+
+      // Estado consistente: ou 204 + removido, ou erro + intacto.
+      // Nesse caminho feliz: 204 e o usuário desaparece.
+      expect(exclusao.status).to.equal(204);
+
+      // Tenta autenticar de novo: garantia de que o usuário sumiu
+      const tentativaLogin = await request(app)
+        .post('/api/auth/login')
+        .send(credenciais);
+
+      expect(tentativaLogin.status).to.equal(401);
+    });
+  });
+
+  // ==========================================================
+  // Cenários de autenticação (cobertos pelo middleware)
+  // ==========================================================
+  describe('Autenticação', () => {
+    it('[US-005][RG-009] deve retornar 401 TOKEN_AUSENTE sem header Authorization', async () => {
+      const response = await request(app)
+        .delete('/api/usuarios/me')
+        .send({ senha: 'qualquer' });
+
+      expect(response.status).to.equal(401);
+      expect(response.body.erro.codigo).to.equal('TOKEN_AUSENTE');
+    });
+
+    it('[US-005][RG-010] deve retornar 401 TOKEN_INVALIDO com token mal formado', async () => {
+      const response = await request(app)
+        .delete('/api/usuarios/me')
+        .set('Authorization', 'Bearer xpto-token-invalido')
+        .send({ senha: 'qualquer' });
+
+      expect(response.status).to.equal(401);
+      expect(response.body.erro.codigo).to.equal('TOKEN_INVALIDO');
+    });
+  });
+});


### PR DESCRIPTION
## 📋 Descrição

Implementa a US-005 (Excluir própria conta) — última User Story do EP-001 (Gestão de Usuários).

Com esta entrega, o **EP-001 fica 100% completo** com todas as 5 User Stories implementadas e testadas.

## 🎯 O que foi feito

### Implementação

#### `repositories/usuario.repository.js` (atualizado)
- Adicionada função `excluir(id)` com prepared statement
- Retorna boolean indicando se a exclusão foi efetiva

#### `services/usuario.service.js` (atualizado)
Função `excluirConta(usuarioId, body)`:
- Valida obrigatoriedade da senha de confirmação
- Verifica se o usuário existe (proteção contra race condition)
- Compara senha com bcrypt (`compararHash`)
- Executa exclusão atômica
- Lança `AppError` com códigos específicos para cada cenário de erro

#### `controllers/usuario.controller.js` (atualizado)
- Handler `excluirConta` delega ao service e responde 204 No Content

#### `routes/usuario.routes.js` (atualizado)
- Registra `DELETE /me` com middleware de autenticação
- Documentação Swagger completa do endpoint

### Testes automatizados — 10 cenários

| Caso | Cenário | Status |
|---|---|:---:|
| CT-EP001-US005-01 | Exclusão com senha correta (204) | ✅ |
| CT-EP001-US005-02 | Senha incorreta (401 CREDENCIAIS_INVALIDAS) | ✅ |
| CT-EP001-US005-03 | Senha ausente (400) | ✅ |
| CT-EP001-US005-03 | Senha vazia (400) | ✅ |
| CT-EP001-US005-04 | Token antigo retorna 404 USUARIO_NAO_ENCONTRADO | ✅ |
| CT-EP001-US005-05 | E-mail volta a ficar livre para novo cadastro | ✅ |
| CT-EP001-US005-06 | Usuário some efetivamente do banco | ✅ |
| CT-EP001-US005-07 | Atomicidade (tudo-ou-nada) | ✅ |
| Auth | TOKEN_AUSENTE | ✅ |
| Auth | TOKEN_INVALIDO | ✅ |

> **Observação sobre CT-06 e CT-07:** A cobertura de cascata real e atomicidade com falhas intermediárias será expandida quando existirem tabelas filhas (contas, categorias, transações). Por enquanto a estrutura de testes está pronta e valida o comportamento básico.

## 📚 Regras de Negócio Cobertas

- **RU-043** — Endpoint DELETE /api/usuarios/me
- **RU-044** — Senha de confirmação obrigatória
- **RU-045** — Usuário removido efetivamente
- **RU-046** — Operação atômica
- **RU-047** — Resposta 204 sem body
- **RU-048** — Token antigo torna-se efetivamente inválido
- **RU-049** — E-mail liberado para reuso
- **RG-009** — TOKEN_AUSENTE (sem header)
- **RG-010** — TOKEN_INVALIDO (token mal formado)
- **RG-014** — Validação de campos obrigatórios
- **RG-038** — Atomicidade das operações

## ✅ Validações realizadas

### Manuais (curl)
- [x] Cadastro → login → exclusão com senha correta (204)
- [x] Exclusão com senha errada (401)
- [x] Exclusão sem senha (400)
- [x] Token antigo após exclusão (404)
- [x] Reuso do e-mail (201)

### Automatizadas
- [x] **52/52 testes passando** (10 novos + 42 existentes)
- [x] Sem regressão em testes anteriores
- [x] Tempo total da suíte preservado

## 🎯 Tipo de mudança

- [x] Feature

## 🔗 Issue relacionada

Closes #19

## 📌 Próximos passos

Com EP-001 completo, próximas entregas são:
- CI/CD (GitHub Actions) com badge no README
- Matriz de Rastreabilidade
- README final com screenshots e GIFs