### PR TITLE
feat(categorias): implementa EP-004 — gestão de categorias
  (US-015 a US-019)

### DIFF
--- a/api/database/migrations/003_create_categorias.sql
+++ b/api/database/migrations/003_create_categorias.sql
@@ -1,0 +1,39 @@
+-- Migration: 003_create_categorias
+-- Cria a tabela de categorias (EP-004)
+
+CREATE TABLE IF NOT EXISTS categorias (
+  id            INTEGER PRIMARY KEY AUTOINCREMENT,
+  nome          TEXT    NOT NULL,
+  tipo          TEXT    NOT NULL,
+  icone         TEXT,
+  padrao        INTEGER NOT NULL DEFAULT 0,
+  usuario_id    INTEGER,
+  criado_em     TEXT    NOT NULL DEFAULT (datetime('now')),
+  atualizado_em TEXT    NOT NULL DEFAULT (datetime('now')),
+
+  FOREIGN KEY (usuario_id) REFERENCES usuarios(id) ON DELETE CASCADE,
+  CHECK (tipo IN ('receita', 'despesa', 'ambos')),
+  CHECK (padrao IN (0, 1))
+);
+
+-- Índice para busca rápida das categorias de um usuário
+CREATE INDEX IF NOT EXISTS idx_categorias_usuario_id ON categorias(usuario_id);
+
+-- Seed: categorias padrão do sistema (RK-006, RK-007)
+
+-- Despesas
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Alimentação', 'despesa', '🍔', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Transporte', 'despesa', '🚗', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Moradia', 'despesa', '🏠', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Saúde', 'despesa', '🏥', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Lazer', 'despesa', '🎮', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Educação', 'despesa', '📚', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Compras', 'despesa', '🛍️', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Serviços', 'despesa', '🔧', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Outros', 'despesa', '📦', 1, NULL);
+
+-- Receitas
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Salário', 'receita', '💼', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Freelance', 'receita', '💻', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Investimentos', 'receita', '📈', 1, NULL);
+INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id) VALUES ('Outros', 'receita', '💰', 1, NULL);

--- a/api/src/app.js
+++ b/api/src/app.js
@@ -7,6 +7,7 @@ import healthRoutes from './routes/health.routes.js';
 import usuarioRoutes from './routes/usuario.routes.js';
 import authRoutes from './routes/auth.routes.js';
 import contaRoutes from './routes/conta.routes.js';
+import categoriaRoutes from './routes/categoria.routes.js';
 import { errorMiddleware } from './middlewares/error.middleware.js';
 
 const app = express();
@@ -28,6 +29,7 @@ app.use('/api/health', healthRoutes);
 app.use('/api/usuarios', usuarioRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/contas', contaRoutes);
+app.use('/api/categorias', categoriaRoutes);
 
 // 404 para rotas não encontradas
 app.use((req, res) => {

--- a/api/src/controllers/categoria.controller.js
+++ b/api/src/controllers/categoria.controller.js
@@ -1,0 +1,73 @@
+import categoriaService from '../services/categoria.service.js';
+
+/**
+ * GET /api/categorias — lista categorias acessíveis (US-015).
+ */
+export function listar(req, res, next) {
+  try {
+    const categorias = categoriaService.listar(req.usuario.id, req.query || {});
+    res.status(200).json(categorias);
+  } catch (erro) {
+    next(erro);
+  }
+}
+
+/**
+ * POST /api/categorias — cria categoria personalizada (US-016).
+ */
+export function criar(req, res, next) {
+  try {
+    const categoria = categoriaService.criar(req.usuario.id, req.body || {});
+    res.status(201).json(categoria);
+  } catch (erro) {
+    next(erro);
+  }
+}
+
+/**
+ * GET /api/categorias/:id — consulta categoria específica (US-017).
+ */
+export function consultar(req, res, next) {
+  try {
+    const categoria = categoriaService.consultar(Number(req.params.id), req.usuario.id);
+    res.status(200).json(categoria);
+  } catch (erro) {
+    next(erro);
+  }
+}
+
+/**
+ * PUT /api/categorias/:id — atualiza categoria personalizada (US-018).
+ */
+export function atualizar(req, res, next) {
+  try {
+    const categoria = categoriaService.atualizar(
+      Number(req.params.id),
+      req.usuario.id,
+      req.body || {}
+    );
+    res.status(200).json(categoria);
+  } catch (erro) {
+    next(erro);
+  }
+}
+
+/**
+ * DELETE /api/categorias/:id — exclui categoria personalizada (US-019).
+ */
+export function excluir(req, res, next) {
+  try {
+    categoriaService.excluir(Number(req.params.id), req.usuario.id);
+    res.status(204).send();
+  } catch (erro) {
+    next(erro);
+  }
+}
+
+export default {
+  listar,
+  criar,
+  consultar,
+  atualizar,
+  excluir,
+};

--- a/api/src/repositories/categoria.repository.js
+++ b/api/src/repositories/categoria.repository.js
@@ -1,0 +1,165 @@
+import db from '../config/database.js';
+
+/**
+ * Insere uma nova categoria personalizada no banco.
+ *
+ * @param {Object} dados
+ * @param {number} dados.usuarioId
+ * @param {string} dados.nome
+ * @param {string} dados.tipo
+ * @param {string|null} dados.icone
+ * @returns {Object} Categoria criada
+ */
+export function inserir({ usuarioId, nome, tipo, icone }) {
+  const stmt = db.prepare(`
+    INSERT INTO categorias (nome, tipo, icone, padrao, usuario_id)
+    VALUES (?, ?, ?, 0, ?)
+  `);
+
+  const resultado = stmt.run(nome, tipo, icone, usuarioId);
+  return buscarPorId(resultado.lastInsertRowid);
+}
+
+/**
+ * Busca uma categoria pelo ID.
+ *
+ * @param {number} id
+ * @returns {Object|undefined}
+ */
+export function buscarPorId(id) {
+  const stmt = db.prepare(`
+    SELECT id, nome, tipo, icone, padrao, usuario_id, criado_em, atualizado_em
+    FROM categorias
+    WHERE id = ?
+  `);
+
+  return stmt.get(id);
+}
+
+/**
+ * Busca uma categoria pelo ID garantindo que é acessível ao usuário.
+ * Retorna se: é padrão OU pertence ao usuário.
+ *
+ * @param {number} id
+ * @param {number} usuarioId
+ * @returns {Object|undefined}
+ */
+export function buscarPorIdAcessivel(id, usuarioId) {
+  const stmt = db.prepare(`
+    SELECT id, nome, tipo, icone, padrao, usuario_id, criado_em, atualizado_em
+    FROM categorias
+    WHERE id = ? AND (padrao = 1 OR usuario_id = ?)
+  `);
+
+  return stmt.get(id, usuarioId);
+}
+
+/**
+ * Lista categorias acessíveis ao usuário (padrão + personalizadas).
+ *
+ * @param {number} usuarioId
+ * @param {Object} filtros
+ * @param {string|undefined} filtros.tipo
+ * @param {string|undefined} filtros.origem - 'padrao' ou 'personalizada'
+ * @returns {Array}
+ */
+export function listarAcessiveis(usuarioId, filtros = {}) {
+  const condicoes = ['(padrao = 1 OR usuario_id = ?)'];
+  const params = [usuarioId];
+
+  if (filtros.tipo) {
+    // Ao filtrar por 'receita' ou 'despesa', inclui também categorias 'ambos'
+    condicoes.push("(tipo = ? OR tipo = 'ambos')");
+    params.push(filtros.tipo);
+  }
+
+  if (filtros.origem === 'padrao') {
+    condicoes.push('padrao = 1');
+  } else if (filtros.origem === 'personalizada') {
+    condicoes.push('padrao = 0');
+  }
+
+  const sql = `
+    SELECT id, nome, tipo, icone, padrao, usuario_id, criado_em, atualizado_em
+    FROM categorias
+    WHERE ${condicoes.join(' AND ')}
+    ORDER BY padrao DESC, nome ASC
+  `;
+
+  return db.prepare(sql).all(...params);
+}
+
+/**
+ * Atualiza nome e/ou ícone de uma categoria.
+ *
+ * @param {number} id
+ * @param {Object} dados
+ * @param {string|undefined} dados.nome
+ * @param {string|null|undefined} dados.icone
+ * @returns {Object} Categoria atualizada
+ */
+export function atualizar(id, dados) {
+  const campos = [];
+  const params = [];
+
+  if (dados.nome !== undefined) {
+    campos.push('nome = ?');
+    params.push(dados.nome);
+  }
+
+  if (dados.icone !== undefined) {
+    campos.push('icone = ?');
+    params.push(dados.icone);
+  }
+
+  campos.push("atualizado_em = datetime('now')");
+  params.push(id);
+
+  const sql = `UPDATE categorias SET ${campos.join(', ')} WHERE id = ?`;
+  db.prepare(sql).run(...params);
+
+  return buscarPorId(id);
+}
+
+/**
+ * Exclui uma categoria permanentemente (hard delete).
+ *
+ * @param {number} id
+ * @returns {boolean} true se excluiu
+ */
+export function excluir(id) {
+  const stmt = db.prepare('DELETE FROM categorias WHERE id = ?');
+  const resultado = stmt.run(id);
+  return resultado.changes > 0;
+}
+
+/**
+ * Conta quantas transações estão vinculadas a uma categoria.
+ * Retorna 0 se a tabela transacoes não existe ainda.
+ *
+ * @param {number} categoriaId
+ * @returns {number}
+ */
+export function contarTransacoes(categoriaId) {
+  const tabelaExiste = db.prepare(`
+    SELECT name FROM sqlite_master WHERE type='table' AND name='transacoes'
+  `).get();
+
+  if (!tabelaExiste) return 0;
+
+  const resultado = db.prepare(`
+    SELECT COUNT(*) as total FROM transacoes WHERE categoria_id = ?
+  `).get(categoriaId);
+
+  return resultado.total;
+}
+
+export default {
+  inserir,
+  buscarPorId,
+  buscarPorIdAcessivel,
+  listarAcessiveis,
+  atualizar,
+  excluir,
+  contarTransacoes,
+};

--- a/api/src/routes/categoria.routes.js
+++ b/api/src/routes/categoria.routes.js
@@ -1,0 +1,247 @@
+import { Router } from 'express';
+import categoriaController from '../controllers/categoria.controller.js';
+import { authMiddleware } from '../middlewares/auth.middleware.js';
+
+const router = Router();
+
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     Categoria:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: integer
+ *           example: 1
+ *         nome:
+ *           type: string
+ *           example: "Alimentação"
+ *         tipo:
+ *           type: string
+ *           enum: [receita, despesa, ambos]
+ *           example: "despesa"
+ *         icone:
+ *           type: string
+ *           nullable: true
+ *           example: "🍔"
+ *         padrao:
+ *           type: boolean
+ *           example: true
+ *         usuarioId:
+ *           type: integer
+ *           nullable: true
+ *           example: null
+ *         criadoEm:
+ *           type: string
+ *           format: date-time
+ *         atualizadoEm:
+ *           type: string
+ *           format: date-time
+ */
+
+/**
+ * @swagger
+ * /api/categorias:
+ *   get:
+ *     tags: [Categorias]
+ *     summary: Lista categorias acessíveis ao usuário
+ *     description: |
+ *       Retorna categorias padrão do sistema + categorias personalizadas do usuário.
+ *       Categorias personalizadas de outros usuários não aparecem.
+ *
+ *       **Filtros:**
+ *       - `?tipo=despesa` — filtra por tipo (inclui categorias do tipo "ambos")
+ *       - `?origem=padrao` ou `?origem=personalizada` — filtra por origem
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: tipo
+ *         schema:
+ *           type: string
+ *           enum: [receita, despesa, ambos]
+ *         description: Filtra por tipo de categoria
+ *       - in: query
+ *         name: origem
+ *         schema:
+ *           type: string
+ *           enum: [padrao, personalizada]
+ *         description: Filtra por origem da categoria
+ *     responses:
+ *       200:
+ *         description: Lista de categorias
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Categoria'
+ *       401:
+ *         description: Token ausente, inválido ou expirado
+ */
+router.get('/', authMiddleware, categoriaController.listar);
+
+/**
+ * @swagger
+ * /api/categorias:
+ *   post:
+ *     tags: [Categorias]
+ *     summary: Cria uma categoria personalizada
+ *     description: |
+ *       Cria uma categoria vinculada ao usuário autenticado.
+ *       Categorias personalizadas têm `padrao = false`.
+ *
+ *       **Tipos aceitos:** receita, despesa, ambos.
+ *       **Ícone:** emoji opcional (máx. 4 caracteres).
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [nome, tipo]
+ *             properties:
+ *               nome:
+ *                 type: string
+ *                 example: "Jogos e Hobbies"
+ *               tipo:
+ *                 type: string
+ *                 enum: [receita, despesa, ambos]
+ *                 example: "despesa"
+ *               icone:
+ *                 type: string
+ *                 nullable: true
+ *                 example: "🎲"
+ *     responses:
+ *       201:
+ *         description: Categoria criada com sucesso
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Categoria'
+ *       400:
+ *         description: Dados inválidos (VALIDACAO ou CAMPO_OBRIGATORIO)
+ *       401:
+ *         description: Token ausente, inválido ou expirado
+ */
+router.post('/', authMiddleware, categoriaController.criar);
+
+/**
+ * @swagger
+ * /api/categorias/{id}:
+ *   get:
+ *     tags: [Categorias]
+ *     summary: Consulta uma categoria específica
+ *     description: |
+ *       Retorna os dados completos de uma categoria.
+ *       Categorias padrão são acessíveis por qualquer usuário autenticado.
+ *       Categorias personalizadas são acessíveis apenas pelo criador.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID da categoria
+ *     responses:
+ *       200:
+ *         description: Dados da categoria
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Categoria'
+ *       401:
+ *         description: Token ausente, inválido ou expirado
+ *       404:
+ *         description: Categoria não encontrada (CATEGORIA_NAO_ENCONTRADA)
+ */
+router.get('/:id', authMiddleware, categoriaController.consultar);
+
+/**
+ * @swagger
+ * /api/categorias/{id}:
+ *   put:
+ *     tags: [Categorias]
+ *     summary: Atualiza uma categoria personalizada
+ *     description: |
+ *       Apenas nome e ícone são editáveis. Tipo é imutável após criação.
+ *       Categorias padrão não podem ser modificadas (retorna 403).
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID da categoria
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               nome:
+ *                 type: string
+ *                 example: "Jogos"
+ *               icone:
+ *                 type: string
+ *                 nullable: true
+ *                 example: "🎮"
+ *     responses:
+ *       200:
+ *         description: Categoria atualizada
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Categoria'
+ *       400:
+ *         description: Campos inválidos ou body vazio
+ *       401:
+ *         description: Token ausente, inválido ou expirado
+ *       403:
+ *         description: Categoria padrão não pode ser modificada (ACESSO_NEGADO)
+ *       404:
+ *         description: Categoria não encontrada (CATEGORIA_NAO_ENCONTRADA)
+ */
+router.put('/:id', authMiddleware, categoriaController.atualizar);
+
+/**
+ * @swagger
+ * /api/categorias/{id}:
+ *   delete:
+ *     tags: [Categorias]
+ *     summary: Exclui uma categoria personalizada
+ *     description: |
+ *       Exclusão permanente (hard delete). Bloqueada quando há transações vinculadas.
+ *       Categorias padrão não podem ser excluídas (retorna 403).
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID da categoria
+ *     responses:
+ *       204:
+ *         description: Categoria excluída com sucesso (sem body)
+ *       401:
+ *         description: Token ausente, inválido ou expirado
+ *       403:
+ *         description: Categoria padrão não pode ser excluída (ACESSO_NEGADO)
+ *       404:
+ *         description: Categoria não encontrada (CATEGORIA_NAO_ENCONTRADA)
+ *       409:
+ *         description: Categoria possui transações vinculadas (CATEGORIA_EM_USO)
+ */
+router.delete('/:id', authMiddleware, categoriaController.excluir);
+
+export default router;

--- a/api/src/services/categoria.service.js
+++ b/api/src/services/categoria.service.js
@@ -1,0 +1,285 @@
+import categoriaRepository from '../repositories/categoria.repository.js';
+import { AppError } from '../middlewares/error.middleware.js';
+
+// ============================================================
+// CONSTANTES
+// ============================================================
+
+const TIPOS_VALIDOS = ['receita', 'despesa', 'ambos'];
+
+// ============================================================
+// VALIDAÇÕES
+// ============================================================
+
+/**
+ * Valida o nome da categoria (RK-015 a RK-018).
+ */
+function validarNome(nome) {
+  if (!nome || typeof nome !== 'string') {
+    return { campo: 'nome', problema: 'Nome é obrigatório.' };
+  }
+
+  const nomeTrim = nome.trim().replace(/\s+/g, ' ');
+
+  if (nomeTrim.length === 0) {
+    return { campo: 'nome', problema: 'Nome é obrigatório.' };
+  }
+
+  if (nomeTrim.length < 2) {
+    return { campo: 'nome', problema: 'Nome deve ter no mínimo 2 caracteres.' };
+  }
+
+  if (nomeTrim.length > 50) {
+    return { campo: 'nome', problema: 'Nome deve ter no máximo 50 caracteres.' };
+  }
+
+  if (/^\d+$/.test(nomeTrim)) {
+    return { campo: 'nome', problema: 'Nome não pode conter apenas números.' };
+  }
+
+  return null;
+}
+
+/**
+ * Valida o tipo da categoria (RK-019 a RK-021).
+ */
+function validarTipo(tipo) {
+  if (!tipo || typeof tipo !== 'string') {
+    return { campo: 'tipo', problema: 'Tipo é obrigatório.' };
+  }
+
+  if (!TIPOS_VALIDOS.includes(tipo)) {
+    return {
+      campo: 'tipo',
+      problema: `Tipo inválido. Valores aceitos: ${TIPOS_VALIDOS.join(', ')}.`,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Valida o ícone da categoria (RK-023 a RK-026).
+ */
+function validarIcone(icone) {
+  if (icone === undefined || icone === null) {
+    return null; // Opcional
+  }
+
+  if (typeof icone !== 'string') {
+    return { campo: 'icone', problema: 'Ícone deve ser uma string.' };
+  }
+
+  if (icone.length > 4) {
+    return { campo: 'icone', problema: 'Ícone deve ter no máximo 4 caracteres.' };
+  }
+
+  return null;
+}
+
+/**
+ * Formata resposta da categoria.
+ */
+function formatarResposta(categoria) {
+  return {
+    id: categoria.id,
+    nome: categoria.nome,
+    tipo: categoria.tipo,
+    icone: categoria.icone,
+    padrao: categoria.padrao === 1,
+    usuarioId: categoria.usuario_id,
+    criadoEm: categoria.criado_em,
+    atualizadoEm: categoria.atualizado_em,
+  };
+}
+
+// ============================================================
+// OPERAÇÕES
+// ============================================================
+
+/**
+ * Lista categorias acessíveis ao usuário (US-015).
+ *
+ * @param {number} usuarioId
+ * @param {Object} filtros - { tipo?, origem? }
+ * @returns {Array}
+ */
+export function listar(usuarioId, filtros = {}) {
+  const filtrosProcessados = {};
+
+  if (filtros.tipo && TIPOS_VALIDOS.includes(filtros.tipo)) {
+    filtrosProcessados.tipo = filtros.tipo;
+  }
+
+  if (filtros.origem === 'padrao' || filtros.origem === 'personalizada') {
+    filtrosProcessados.origem = filtros.origem;
+  }
+
+  const categorias = categoriaRepository.listarAcessiveis(usuarioId, filtrosProcessados);
+  return categorias.map(formatarResposta);
+}
+
+/**
+ * Cria categoria personalizada (US-016).
+ *
+ * @param {number} usuarioId
+ * @param {Object} dados - { nome, tipo, icone? }
+ * @returns {Object} Categoria criada
+ */
+export function criar(usuarioId, dados) {
+  const { nome, tipo, icone } = dados;
+
+  const erros = [];
+
+  const erroNome = validarNome(nome);
+  if (erroNome) erros.push(erroNome);
+
+  const erroTipo = validarTipo(tipo);
+  if (erroTipo) erros.push(erroTipo);
+
+  const erroIcone = validarIcone(icone);
+  if (erroIcone) erros.push(erroIcone);
+
+  if (erros.length > 0) {
+    const todosSaoObrigatorios = erros.every((e) =>
+      e.problema.toLowerCase().includes('obrigatóri')
+    );
+
+    const codigo = todosSaoObrigatorios ? 'CAMPO_OBRIGATORIO' : 'VALIDACAO';
+    const mensagem = todosSaoObrigatorios
+      ? 'Um ou mais campos obrigatórios não foram informados.'
+      : 'Existem campos inválidos na requisição.';
+
+    throw new AppError(codigo, mensagem, 400, erros);
+  }
+
+  const nomeTrim = nome.trim().replace(/\s+/g, ' ');
+  const iconeFinal = icone !== undefined && icone !== null ? icone : null;
+
+  const categoria = categoriaRepository.inserir({
+    usuarioId,
+    nome: nomeTrim,
+    tipo,
+    icone: iconeFinal,
+  });
+
+  return formatarResposta(categoria);
+}
+
+/**
+ * Consulta categoria específica (US-017).
+ *
+ * @param {number} categoriaId
+ * @param {number} usuarioId
+ * @returns {Object}
+ */
+export function consultar(categoriaId, usuarioId) {
+  const categoria = categoriaRepository.buscarPorIdAcessivel(categoriaId, usuarioId);
+
+  if (!categoria) {
+    throw new AppError('CATEGORIA_NAO_ENCONTRADA', 'Categoria não encontrada.', 404);
+  }
+
+  return formatarResposta(categoria);
+}
+
+/**
+ * Atualiza categoria personalizada (US-018).
+ *
+ * @param {number} categoriaId
+ * @param {number} usuarioId
+ * @param {Object} body - { nome?, icone? }
+ * @returns {Object}
+ */
+export function atualizar(categoriaId, usuarioId, body = {}) {
+  const categoria = categoriaRepository.buscarPorIdAcessivel(categoriaId, usuarioId);
+
+  if (!categoria) {
+    throw new AppError('CATEGORIA_NAO_ENCONTRADA', 'Categoria não encontrada.', 404);
+  }
+
+  // RK-049: categorias padrão não podem ser atualizadas
+  if (categoria.padrao === 1) {
+    throw new AppError(
+      'ACESSO_NEGADO',
+      'Categorias padrão do sistema não podem ser modificadas.',
+      403
+    );
+  }
+
+  const temNome = Object.prototype.hasOwnProperty.call(body, 'nome');
+  const temIcone = Object.prototype.hasOwnProperty.call(body, 'icone');
+
+  if (!temNome && !temIcone) {
+    throw new AppError(
+      'CORPO_VAZIO',
+      'Informe ao menos um campo (nome ou icone) para atualizar.',
+      400
+    );
+  }
+
+  const dadosAtualizar = {};
+  const erros = [];
+
+  if (temNome) {
+    const erroNome = validarNome(body.nome);
+    if (erroNome) erros.push(erroNome);
+    else dadosAtualizar.nome = body.nome.trim().replace(/\s+/g, ' ');
+  }
+
+  if (temIcone) {
+    const erroIcone = validarIcone(body.icone);
+    if (erroIcone) erros.push(erroIcone);
+    else dadosAtualizar.icone = body.icone;
+  }
+
+  if (erros.length > 0) {
+    throw new AppError('VALIDACAO', 'Existem campos inválidos na requisição.', 400, erros);
+  }
+
+  const atualizada = categoriaRepository.atualizar(categoriaId, dadosAtualizar);
+  return formatarResposta(atualizada);
+}
+
+/**
+ * Exclui categoria personalizada (US-019).
+ *
+ * @param {number} categoriaId
+ * @param {number} usuarioId
+ */
+export function excluir(categoriaId, usuarioId) {
+  const categoria = categoriaRepository.buscarPorIdAcessivel(categoriaId, usuarioId);
+
+  if (!categoria) {
+    throw new AppError('CATEGORIA_NAO_ENCONTRADA', 'Categoria não encontrada.', 404);
+  }
+
+  // RK-044: categorias padrão não podem ser excluídas
+  if (categoria.padrao === 1) {
+    throw new AppError(
+      'ACESSO_NEGADO',
+      'Categorias padrão do sistema não podem ser excluídas.',
+      403
+    );
+  }
+
+  // RK-046: categoria com transações não pode ser excluída
+  const totalTransacoes = categoriaRepository.contarTransacoes(categoriaId);
+  if (totalTransacoes > 0) {
+    throw new AppError(
+      'CATEGORIA_EM_USO',
+      `Esta categoria possui ${totalTransacoes} transação(ões) vinculada(s) e não pode ser excluída.`,
+      409
+    );
+  }
+
+  categoriaRepository.excluir(categoriaId);
+}
+
+export default {
+  listar,
+  criar,
+  consultar,
+  atualizar,
+  excluir,
+};

--- a/api/tests/api/categorias/atualizar.test.js
+++ b/api/tests/api/categorias/atualizar.test.js
@@ -1,0 +1,128 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import app from '../../../src/app.js';
+import { limparBanco } from '../../helpers/database.helper.js';
+import {
+  criarUsuarioAutenticado,
+  criarCategoriaNoBanco,
+  buscarCategoriaPadrao,
+} from '../../fixtures/categorias.fixtures.js';
+
+const agent = request(app);
+
+describe('PUT /api/categorias/:id — Atualizar categoria personalizada (US-018)', () => {
+  beforeEach(() => {
+    limparBanco();
+  });
+
+  describe('Fluxo feliz', () => {
+    it('[CT-EP004-US018-01][US-018][RK-038] deve atualizar nome da categoria', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      const cat = criarCategoriaNoBanco(usuario.id, { nome: 'Nome Antigo', tipo: 'despesa' });
+
+      const res = await agent
+        .put(`/api/categorias/${cat.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ nome: 'Nome Novo' });
+
+      expect(res.status).to.equal(200);
+      expect(res.body.nome).to.equal('Nome Novo');
+      expect(res.body.tipo).to.equal('despesa'); // Imutável
+    });
+
+    it('[CT-EP004-US018-02][US-018][RK-038] deve atualizar ícone da categoria', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      const cat = criarCategoriaNoBanco(usuario.id, { nome: 'Cat', icone: '🎯' });
+
+      const res = await agent
+        .put(`/api/categorias/${cat.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ icone: '🎮' });
+
+      expect(res.status).to.equal(200);
+      expect(res.body.icone).to.equal('🎮');
+    });
+
+    it('[CT-EP004-US018-03][US-018][RK-042] deve permitir remover ícone com null', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      const cat = criarCategoriaNoBanco(usuario.id, { nome: 'Cat', icone: '🎯' });
+
+      const res = await agent
+        .put(`/api/categorias/${cat.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ icone: null });
+
+      expect(res.status).to.equal(200);
+      expect(res.body.icone).to.equal(null);
+    });
+  });
+
+  describe('Proteção de categorias padrão', () => {
+    it('[CT-EP004-US018-04][US-018][RK-049] deve retornar 403 ao tentar editar categoria padrão', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+      const padrao = buscarCategoriaPadrao();
+
+      const res = await agent
+        .put(`/api/categorias/${padrao.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ nome: 'Tentativa' });
+
+      expect(res.status).to.equal(403);
+      expect(res.body.erro.codigo).to.equal('ACESSO_NEGADO');
+    });
+  });
+
+  describe('Validações', () => {
+    it('[CT-EP004-US018-05][US-018] deve rejeitar body vazio (400)', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      const cat = criarCategoriaNoBanco(usuario.id, { nome: 'Cat' });
+
+      const res = await agent
+        .put(`/api/categorias/${cat.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({});
+
+      expect(res.status).to.equal(400);
+      expect(res.body.erro.codigo).to.equal('CORPO_VAZIO');
+    });
+
+    it('[CT-EP004-US018-06][US-018][RK-041] deve rejeitar nome vazio (400)', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      const cat = criarCategoriaNoBanco(usuario.id, { nome: 'Cat' });
+
+      const res = await agent
+        .put(`/api/categorias/${cat.id}`)
+        .set('Authorization', `Bearer ${token}`)
+        .send({ nome: '' });
+
+      expect(res.status).to.equal(400);
+    });
+  });
+
+  describe('Categoria não encontrada', () => {
+    it('[CT-EP004-US018-07][US-018] deve retornar 404 para ID inexistente', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+
+      const res = await agent
+        .put('/api/categorias/99999')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ nome: 'Teste' });
+
+      expect(res.status).to.equal(404);
+    });
+
+    it('[CT-EP004-US018-08][US-018][RK-037] deve retornar 404 para categoria de outro usuário', async () => {
+      const user1 = await criarUsuarioAutenticado(agent);
+      const user2 = await criarUsuarioAutenticado(agent);
+
+      const catUser2 = criarCategoriaNoBanco(user2.usuario.id, { nome: 'Alheia' });
+
+      const res = await agent
+        .put(`/api/categorias/${catUser2.id}`)
+        .set('Authorization', `Bearer ${user1.token}`)
+        .send({ nome: 'Tentativa' });
+
+      expect(res.status).to.equal(404);
+    });
+  });
+});

--- a/api/tests/api/categorias/consultar.test.js
+++ b/api/tests/api/categorias/consultar.test.js
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import app from '../../../src/app.js';
+import { limparBanco } from '../../helpers/database.helper.js';
+import {
+  criarUsuarioAutenticado,
+  criarCategoriaNoBanco,
+  buscarCategoriaPadrao,
+} from '../../fixtures/categorias.fixtures.js';
+
+const agent = request(app);
+
+describe('GET /api/categorias/:id — Consultar categoria específica (US-017)', () => {
+  beforeEach(() => {
+    limparBanco();
+  });
+
+  describe('Fluxo feliz', () => {
+    it('[CT-EP004-US017-01][US-017][RK-034] deve consultar categoria padrão com sucesso', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+      const padrao = buscarCategoriaPadrao('despesa');
+
+      const res = await agent
+        .get(`/api/categorias/${padrao.id}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.padrao).to.equal(true);
+      expect(res.body).to.have.property('nome');
+      expect(res.body).to.have.property('tipo');
+    });
+
+    it('[CT-EP004-US017-02][US-017][RK-033] deve consultar categoria personalizada própria', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      const cat = criarCategoriaNoBanco(usuario.id, { nome: 'Minha Cat', tipo: 'receita', icone: '🎯' });
+
+      const res = await agent
+        .get(`/api/categorias/${cat.id}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body.id).to.equal(cat.id);
+      expect(res.body.nome).to.equal('Minha Cat');
+      expect(res.body.padrao).to.equal(false);
+    });
+  });
+
+  describe('Categoria não encontrada', () => {
+    it('[CT-EP004-US017-03][US-017][RK-036] deve retornar 404 para ID inexistente', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+
+      const res = await agent
+        .get('/api/categorias/99999')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(404);
+      expect(res.body.erro.codigo).to.equal('CATEGORIA_NAO_ENCONTRADA');
+    });
+
+    it('[CT-EP004-US017-04][US-017][RK-035] deve retornar 404 para categoria personalizada de outro usuário', async () => {
+      const user1 = await criarUsuarioAutenticado(agent);
+      const user2 = await criarUsuarioAutenticado(agent);
+
+      const catUser2 = criarCategoriaNoBanco(user2.usuario.id, { nome: 'Alheia' });
+
+      const res = await agent
+        .get(`/api/categorias/${catUser2.id}`)
+        .set('Authorization', `Bearer ${user1.token}`);
+
+      expect(res.status).to.equal(404);
+      expect(res.body.erro.codigo).to.equal('CATEGORIA_NAO_ENCONTRADA');
+    });
+  });
+
+  describe('Autenticação', () => {
+    it('[CT-EP004-US017-05][US-017][RG-009] deve retornar 401 sem token', async () => {
+      const res = await agent.get('/api/categorias/1');
+      expect(res.status).to.equal(401);
+    });
+  });
+});

--- a/api/tests/api/categorias/criar.test.js
+++ b/api/tests/api/categorias/criar.test.js
@@ -1,0 +1,117 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import app from '../../../src/app.js';
+import { limparBanco } from '../../helpers/database.helper.js';
+import {
+  gerarCategoriaValida,
+  criarUsuarioAutenticado,
+} from '../../fixtures/categorias.fixtures.js';
+
+const agent = request(app);
+
+describe('POST /api/categorias — Criar categoria personalizada (US-016)', () => {
+  beforeEach(() => {
+    limparBanco();
+  });
+
+  describe('Fluxo feliz', () => {
+    it('[CT-EP004-US016-01][US-016][RK-010,RK-012] deve criar categoria com dados válidos', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+      const cat = gerarCategoriaValida();
+
+      const res = await agent
+        .post('/api/categorias')
+        .set('Authorization', `Bearer ${token}`)
+        .send(cat);
+
+      expect(res.status).to.equal(201);
+      expect(res.body).to.have.property('id');
+      expect(res.body.nome).to.equal(cat.nome);
+      expect(res.body.tipo).to.equal(cat.tipo);
+      expect(res.body.icone).to.equal(cat.icone);
+      expect(res.body.padrao).to.equal(false);
+      expect(res.body).to.have.property('criadoEm');
+    });
+
+    it('[CT-EP004-US016-02][US-016][RK-023] deve criar categoria sem ícone (null)', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+
+      const res = await agent
+        .post('/api/categorias')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ nome: 'Sem Icone', tipo: 'despesa' });
+
+      expect(res.status).to.equal(201);
+      expect(res.body.icone).to.equal(null);
+    });
+
+    it('[CT-EP004-US016-03][US-016][RK-004] deve aceitar os 3 tipos válidos', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+
+      for (const tipo of ['receita', 'despesa', 'ambos']) {
+        const res = await agent
+          .post('/api/categorias')
+          .set('Authorization', `Bearer ${token}`)
+          .send({ nome: `Cat ${tipo}`, tipo });
+
+        expect(res.status).to.equal(201);
+        expect(res.body.tipo).to.equal(tipo);
+      }
+    });
+
+    it('[CT-EP004-US016-04][US-016][RK-008] padrao deve ser sempre false para criação via API', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+
+      const res = await agent
+        .post('/api/categorias')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ nome: 'Tentativa Padrão', tipo: 'despesa', padrao: true });
+
+      expect(res.status).to.equal(201);
+      expect(res.body.padrao).to.equal(false);
+    });
+  });
+
+  describe('Validações', () => {
+    it('[CT-EP004-US016-05][US-016][RK-010] deve rejeitar nome ausente (400)', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+
+      const res = await agent
+        .post('/api/categorias')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ tipo: 'despesa' });
+
+      expect(res.status).to.equal(400);
+    });
+
+    it('[CT-EP004-US016-06][US-016][RK-020] deve rejeitar tipo inválido (400)', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+
+      const res = await agent
+        .post('/api/categorias')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ nome: 'Cat', tipo: 'invalido' });
+
+      expect(res.status).to.equal(400);
+    });
+
+    it('[CT-EP004-US016-07][US-016][RK-017] deve rejeitar nome apenas com números (400)', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+
+      const res = await agent
+        .post('/api/categorias')
+        .set('Authorization', `Bearer ${token}`)
+        .send({ nome: '12345', tipo: 'despesa' });
+
+      expect(res.status).to.equal(400);
+    });
+  });
+
+  describe('Autenticação', () => {
+    it('[CT-EP004-US016-08][US-016][RG-009] deve retornar 401 sem token', async () => {
+      const res = await agent.post('/api/categorias').send(gerarCategoriaValida());
+      expect(res.status).to.equal(401);
+      expect(res.body.erro.codigo).to.equal('TOKEN_AUSENTE');
+    });
+  });
+});

--- a/api/tests/api/categorias/excluir.test.js
+++ b/api/tests/api/categorias/excluir.test.js
@@ -1,0 +1,86 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import app from '../../../src/app.js';
+import { limparBanco } from '../../helpers/database.helper.js';
+import {
+  criarUsuarioAutenticado,
+  criarCategoriaNoBanco,
+  buscarCategoriaPadrao,
+} from '../../fixtures/categorias.fixtures.js';
+
+const agent = request(app);
+
+describe('DELETE /api/categorias/:id — Excluir categoria personalizada (US-019)', () => {
+  beforeEach(() => {
+    limparBanco();
+  });
+
+  describe('Fluxo feliz', () => {
+    it('[CT-EP004-US019-01][US-019][RK-045,RK-047] deve excluir categoria sem transações e retornar 204', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      const cat = criarCategoriaNoBanco(usuario.id, { nome: 'Para Excluir', tipo: 'despesa' });
+
+      const res = await agent
+        .delete(`/api/categorias/${cat.id}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(204);
+      expect(res.body).to.be.empty;
+
+      // Confirma que foi removida
+      const consulta = await agent
+        .get(`/api/categorias/${cat.id}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(consulta.status).to.equal(404);
+    });
+  });
+
+  describe('Proteção de categorias padrão', () => {
+    it('[CT-EP004-US019-02][US-019][RK-044] deve retornar 403 ao tentar excluir categoria padrão', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+      const padrao = buscarCategoriaPadrao();
+
+      const res = await agent
+        .delete(`/api/categorias/${padrao.id}`)
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(403);
+      expect(res.body.erro.codigo).to.equal('ACESSO_NEGADO');
+    });
+  });
+
+  describe('Erros', () => {
+    it('[CT-EP004-US019-03][US-019] deve retornar 404 para ID inexistente', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+
+      const res = await agent
+        .delete('/api/categorias/99999')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(404);
+      expect(res.body.erro.codigo).to.equal('CATEGORIA_NAO_ENCONTRADA');
+    });
+
+    it('[CT-EP004-US019-04][US-019][RK-044] deve retornar 404 para categoria de outro usuário', async () => {
+      const user1 = await criarUsuarioAutenticado(agent);
+      const user2 = await criarUsuarioAutenticado(agent);
+
+      const catUser2 = criarCategoriaNoBanco(user2.usuario.id, { nome: 'Alheia' });
+
+      const res = await agent
+        .delete(`/api/categorias/${catUser2.id}`)
+        .set('Authorization', `Bearer ${user1.token}`);
+
+      expect(res.status).to.equal(404);
+    });
+  });
+
+  describe('Autenticação', () => {
+    it('[CT-EP004-US019-05][US-019][RG-009] deve retornar 401 sem token', async () => {
+      const res = await agent.delete('/api/categorias/1');
+      expect(res.status).to.equal(401);
+      expect(res.body.erro.codigo).to.equal('TOKEN_AUSENTE');
+    });
+  });
+});

--- a/api/tests/api/categorias/listar.test.js
+++ b/api/tests/api/categorias/listar.test.js
@@ -1,0 +1,112 @@
+import { expect } from 'chai';
+import request from 'supertest';
+import app from '../../../src/app.js';
+import { limparBanco } from '../../helpers/database.helper.js';
+import {
+  criarUsuarioAutenticado,
+  criarCategoriaNoBanco,
+} from '../../fixtures/categorias.fixtures.js';
+
+const agent = request(app);
+
+describe('GET /api/categorias — Listar categorias disponíveis (US-015)', () => {
+  beforeEach(() => {
+    limparBanco();
+  });
+
+  describe('Fluxo feliz', () => {
+    it('[CT-EP004-US015-01][US-015][RK-027] deve listar categorias padrão + personalizadas do usuário', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      criarCategoriaNoBanco(usuario.id, { nome: 'Minha Categoria', tipo: 'despesa' });
+
+      const res = await agent
+        .get('/api/categorias')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.be.an('array');
+
+      const padrao = res.body.filter((c) => c.padrao === true);
+      const personalizada = res.body.filter((c) => c.padrao === false);
+
+      expect(padrao.length).to.be.greaterThan(0);
+      expect(personalizada).to.have.lengthOf(1);
+      expect(personalizada[0].nome).to.equal('Minha Categoria');
+    });
+
+    it('[CT-EP004-US015-02][US-015][RK-028] categorias padrão aparecem primeiro, ordenadas por nome', async () => {
+      const { token } = await criarUsuarioAutenticado(agent);
+
+      const res = await agent
+        .get('/api/categorias')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(200);
+      // Primeira categoria deve ser padrão
+      expect(res.body[0].padrao).to.equal(true);
+    });
+
+    it('[CT-EP004-US015-03][US-015][RK-029] deve filtrar por tipo (inclui tipo ambos)', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      criarCategoriaNoBanco(usuario.id, { nome: 'Cat Ambos', tipo: 'ambos' });
+
+      const res = await agent
+        .get('/api/categorias?tipo=despesa')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(200);
+      res.body.forEach((c) => {
+        expect(['despesa', 'ambos']).to.include(c.tipo);
+      });
+    });
+
+    it('[CT-EP004-US015-04][US-015][RK-030] deve filtrar por origem=padrao', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      criarCategoriaNoBanco(usuario.id, { nome: 'Personalizada', tipo: 'despesa' });
+
+      const res = await agent
+        .get('/api/categorias?origem=padrao')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(200);
+      res.body.forEach((c) => expect(c.padrao).to.equal(true));
+    });
+
+    it('[CT-EP004-US015-05][US-015][RK-030] deve filtrar por origem=personalizada', async () => {
+      const { token, usuario } = await criarUsuarioAutenticado(agent);
+      criarCategoriaNoBanco(usuario.id, { nome: 'Minha', tipo: 'receita' });
+
+      const res = await agent
+        .get('/api/categorias?origem=personalizada')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.have.lengthOf(1);
+      res.body.forEach((c) => expect(c.padrao).to.equal(false));
+    });
+  });
+
+  describe('Isolamento', () => {
+    it('[CT-EP004-US015-06][US-015][RK-003] não deve listar categorias personalizadas de outro usuário', async () => {
+      const user1 = await criarUsuarioAutenticado(agent);
+      const user2 = await criarUsuarioAutenticado(agent);
+
+      criarCategoriaNoBanco(user2.usuario.id, { nome: 'Categoria do User 2', tipo: 'despesa' });
+
+      const res = await agent
+        .get('/api/categorias?origem=personalizada')
+        .set('Authorization', `Bearer ${user1.token}`);
+
+      expect(res.status).to.equal(200);
+      expect(res.body).to.have.lengthOf(0);
+    });
+  });
+
+  describe('Autenticação', () => {
+    it('[CT-EP004-US015-07][US-015][RG-009] deve retornar 401 sem token', async () => {
+      const res = await agent.get('/api/categorias');
+      expect(res.status).to.equal(401);
+      expect(res.body.erro.codigo).to.equal('TOKEN_AUSENTE');
+    });
+  });
+});

--- a/api/tests/fixtures/categorias.fixtures.js
+++ b/api/tests/fixtures/categorias.fixtures.js
@@ -1,0 +1,94 @@
+/**
+ * ============================================================
+ * FIXTURES DE TESTE — CATEGORIAS
+ * ============================================================
+ *
+ * Factories e helpers para testes do EP-004 (Gestão de Categorias).
+ * ============================================================
+ */
+
+import { randomInt } from 'crypto';
+import categoriaRepository from '../../src/repositories/categoria.repository.js';
+import { criarUsuarioParaLogin } from './auth.fixtures.js';
+
+// ------------------------------------------------------------
+// CONSTANTES
+// ------------------------------------------------------------
+
+const TIPOS_VALIDOS = ['receita', 'despesa', 'ambos'];
+
+const NOMES_CATEGORIAS = [
+  'Academia', 'Pets', 'Jogos', 'Assinaturas', 'Presentes',
+  'Viagens', 'Vestuário', 'Streaming', 'Doações', 'Seguros',
+];
+
+// ------------------------------------------------------------
+// FACTORIES VÁLIDAS
+// ------------------------------------------------------------
+
+/**
+ * Gera dados válidos para criação de categoria.
+ */
+export function gerarCategoriaValida(overrides = {}) {
+  return {
+    nome: NOMES_CATEGORIAS[randomInt(0, NOMES_CATEGORIAS.length)] + ' ' + randomInt(100, 999),
+    tipo: TIPOS_VALIDOS[randomInt(0, TIPOS_VALIDOS.length)],
+    icone: '🎯',
+    ...overrides,
+  };
+}
+
+// ------------------------------------------------------------
+// HELPERS DE BANCO
+// ------------------------------------------------------------
+
+/**
+ * Cria um usuário autenticado e retorna token + dados.
+ */
+export async function criarUsuarioAutenticado(requestAgent, overrides = {}) {
+  const { usuario, credenciais } = await criarUsuarioParaLogin(overrides);
+
+  const login = await requestAgent
+    .post('/api/auth/login')
+    .send(credenciais);
+
+  return {
+    token: login.body.token,
+    usuario,
+    credenciais,
+  };
+}
+
+/**
+ * Cria uma categoria personalizada diretamente no banco.
+ */
+export function criarCategoriaNoBanco(usuarioId, overrides = {}) {
+  const dados = gerarCategoriaValida(overrides);
+  return categoriaRepository.inserir({
+    usuarioId,
+    nome: dados.nome,
+    tipo: dados.tipo,
+    icone: dados.icone,
+  });
+}
+
+/**
+ * Retorna o ID de uma categoria padrão existente no banco.
+ * Útil para testes que precisam de uma categoria padrão.
+ */
+export function buscarCategoriaPadrao(tipo = 'despesa') {
+  const categorias = categoriaRepository.listarAcessiveis(0, { tipo });
+  return categorias.find((c) => c.padrao === 1);
+}
+
+// ------------------------------------------------------------
+// EXPORT DEFAULT
+// ------------------------------------------------------------
+
+export default {
+  gerarCategoriaValida,
+  criarUsuarioAutenticado,
+  criarCategoriaNoBanco,
+  buscarCategoriaPadrao,
+  TIPOS_VALIDOS,
+};

--- a/api/tests/helpers/database.helper.js
+++ b/api/tests/helpers/database.helper.js
@@ -16,10 +16,12 @@ export function limparBanco() {
   }
 
   // Ordem importa quando houver FKs (filho antes, pai depois)
+  db.exec('DELETE FROM categorias WHERE padrao = 0;');
   db.exec('DELETE FROM contas;');
   db.exec('DELETE FROM usuarios;');
 
   // Reseta auto-increment para IDs começarem do 1
+  db.exec("DELETE FROM sqlite_sequence WHERE name='categorias';");
   db.exec("DELETE FROM sqlite_sequence WHERE name='contas';");
   db.exec("DELETE FROM sqlite_sequence WHERE name='usuarios';");
 }

--- a/docs/05-user-stories/ep-004-categorias.md
+++ b/docs/05-user-stories/ep-004-categorias.md
@@ -1,0 +1,773 @@
+# 📄 User Stories — EP-004: Gestão de Categorias
+
+> Documento com as User Stories do **Épico 4 — Gestão de Categorias**, que cobre listagem, criação, consulta, atualização e exclusão de categorias de transações (padrão e personalizadas).
+
+---
+
+## 📋 Sumário
+
+- [Sobre Este Documento](#-sobre-este-documento)
+- [Resumo do Épico](#-resumo-do-épico)
+- [US-015 — Listar categorias](#us-015--listar-categorias)
+- [US-016 — Criar categoria personalizada](#us-016--criar-categoria-personalizada)
+- [US-017 — Consultar categoria](#us-017--consultar-categoria)
+- [US-018 — Atualizar categoria personalizada](#us-018--atualizar-categoria-personalizada)
+- [US-019 — Excluir categoria personalizada](#us-019--excluir-categoria-personalizada)
+- [Resumo de Cobertura](#-resumo-de-cobertura)
+
+---
+
+## 📖 Sobre Este Documento
+
+Este documento lista as **User Stories** do EP-004. Cada US é uma unidade de valor independente, rastreável até regras de negócio e pronta para ser transformada em issue no GitHub.
+
+### Estrutura de cada US
+
+- **Narrativa** — padrão "Como… Quero… Para que…"
+- **Contexto** — explicação da relevância e persona envolvida
+- **Especificação** — endpoint e autenticação
+- **Critérios de Aceitação** — em Gherkin (Dado/Quando/Então)
+- **Regras de Negócio Cobertas** — lista rastreável
+- **Labels** — tags para a issue no GitHub
+- **Definition of Done** — checklist de conclusão
+
+### Sistema de IDs
+
+- `US-XXX` — User Story (identificador único sequencial)
+- `CA-XX` — Critério de Aceitação (interno a cada US)
+
+---
+
+## 📦 Resumo do Épico
+
+| Informação | Valor |
+|---|---|
+| **Épico** | EP-004 — Gestão de Categorias |
+| **Prioridade** | 🟡 Alta |
+| **Sprint** | 2 |
+| **User Stories** | 5 |
+| **Endpoints envolvidos** | 5 |
+| **Regras de negócio cobertas** | RK-001 a RK-056 |
+
+### Lista de User Stories
+
+| ID | Título | Endpoint |
+|---|---|---|
+| US-015 | Listar categorias | `GET /api/categorias` |
+| US-016 | Criar categoria personalizada | `POST /api/categorias` |
+| US-017 | Consultar categoria | `GET /api/categorias/:id` |
+| US-018 | Atualizar categoria personalizada | `PUT /api/categorias/:id` |
+| US-019 | Excluir categoria personalizada | `DELETE /api/categorias/:id` |
+
+### Categorias padrão (seed)
+
+O sistema é inicializado com **13 categorias padrão** (`padrao = true`), criadas via seed e disponíveis para todos os usuários (conforme RK-007):
+
+- **9 categorias de despesa:** Alimentação, Transporte, Moradia, Saúde, Educação, Lazer, Vestuário, Serviços e Outros (despesa)
+- **4 categorias de receita:** Salário, Freelance, Investimentos e Outros (receita)
+
+---
+
+## US-015 — Listar categorias
+
+![Épico](https://img.shields.io/badge/épico-EP--004-green)
+![Prioridade](https://img.shields.io/badge/prioridade-crítica-red)
+![Fase](https://img.shields.io/badge/fase-2-purple)
+
+### 📖 Narrativa
+
+> **Como** usuária autenticada no Provus Finance,
+> **Quero** listar todas as categorias disponíveis (padrão e minhas personalizadas),
+> **Para que** eu possa escolher a categoria correta ao registrar uma transação.
+
+### 🎯 Contexto
+
+A listagem de categorias é a **base para classificação de transações**. Sem ela, o usuário não consegue associar receitas e despesas a categorias. O endpoint combina categorias padrão do sistema com as personalizadas do usuário autenticado, e permite filtrar por tipo (receita/despesa) e origem (padrao/personalizada).
+
+**Persona principal:** Ana (iniciante, precisa visualizar as opções disponíveis)
+
+### 🔌 Especificação
+
+- **Endpoint:** `GET /api/categorias`
+- **Autenticação:** ✅ Token JWT obrigatório
+- **Query params:** `tipo` (receita, despesa, ambos), `padrao` (true, false)
+
+### ✅ Critérios de Aceitação
+
+#### CA-01 — Listagem retorna categorias padrão e personalizadas
+
+```gherkin
+Dado que estou autenticado
+  E existem categorias padrão no sistema
+  E eu tenho categorias personalizadas criadas
+Quando consulto GET /api/categorias sem filtros
+Então a resposta deve ter status 200
+  E o corpo deve conter as categorias padrão do sistema
+  E o corpo deve conter as minhas categorias personalizadas
+  E não deve conter categorias personalizadas de outros usuários
+```
+
+#### CA-02 — Filtro por tipo funciona corretamente
+
+```gherkin
+Dado que estou autenticado
+Quando consulto GET /api/categorias?tipo=despesa
+Então a resposta deve ter status 200
+  E todas as categorias retornadas devem ter tipo "despesa" ou "ambos"
+  E categorias exclusivamente de receita não devem aparecer
+```
+
+#### CA-03 — Filtro por origem funciona corretamente
+
+```gherkin
+Dado que estou autenticado
+Quando consulto GET /api/categorias?padrao=true
+Então a resposta deve ter status 200
+  E todas as categorias retornadas devem ter padrao = true
+  E nenhuma categoria personalizada deve aparecer
+```
+
+#### CA-04 — Usuário sem categorias personalizadas vê apenas padrão
+
+```gherkin
+Dado que estou autenticado
+  E não criei nenhuma categoria personalizada
+Quando consulto GET /api/categorias
+Então a resposta deve ter status 200
+  E o corpo deve conter apenas as 13 categorias padrão
+```
+
+#### CA-05 — Sem autenticação
+
+```gherkin
+Dado que envio a requisição sem token
+Quando consulto GET /api/categorias
+Então a resposta deve ter status 401
+  E o código do erro deve ser "TOKEN_AUSENTE"
+```
+
+#### CA-06 — Cada categoria contém campos esperados
+
+```gherkin
+Dado que estou autenticado
+Quando consulto GET /api/categorias
+Então cada categoria deve conter id, nome, tipo, icone, padrao e criadoEm
+```
+
+### 📚 Regras de Negócio Cobertas
+
+| ID | Descrição |
+|---|---|
+| RK-027 | Listagem retorna categorias padrão + personalizadas do usuário |
+| RK-028 | Categorias personalizadas de outros usuários não aparecem |
+| RK-029 | Filtro por tipo é opcional |
+| RK-030 | Filtro por origem (padrao) é opcional |
+| RK-031 | Listagem retorna campos públicos da categoria |
+| RK-032 | Listagem exige autenticação |
+| RG-008 | Rotas protegidas exigem token JWT válido |
+| RG-009 | Token ausente retorna 401 |
+
+### 🏷️ Labels para a Issue
+
+- `epic:categorias`
+- `tipo:api`
+- `tipo:testes`
+- `fase-2`
+- `prioridade:critica`
+
+### ✔️ Definition of Done
+
+- [x] Endpoint `GET /api/categorias` implementado
+- [x] Listagem combina categorias padrão + personalizadas do usuário
+- [x] Filtros por tipo e origem funcionando
+- [x] Todos os critérios de aceitação passando
+- [x] Testes automatizados escritos e passando
+- [x] Documentação Swagger atualizada
+- [x] Código revisado via Pull Request
+- [x] Branch mergeada na `main`
+
+### 📌 Observações
+
+- Categorias padrão são visíveis por **todos** os usuários autenticados
+- Categorias personalizadas são visíveis **apenas pelo criador**
+- O filtro `tipo=ambos` retorna categorias que servem tanto para receita quanto despesa
+
+---
+
+## US-016 — Criar categoria personalizada
+
+![Épico](https://img.shields.io/badge/épico-EP--004-green)
+![Prioridade](https://img.shields.io/badge/prioridade-alta-yellow)
+![Fase](https://img.shields.io/badge/fase-2-purple)
+
+### 📖 Narrativa
+
+> **Como** usuário autenticado no Provus Finance,
+> **Quero** criar uma categoria personalizada informando nome, tipo e opcionalmente um ícone,
+> **Para que** eu possa classificar minhas transações de forma mais adequada à minha realidade financeira.
+
+### 🎯 Contexto
+
+As 13 categorias padrão cobrem os cenários mais comuns, mas usuários avançados precisam de **flexibilidade** para criar categorias que reflitam seus hábitos específicos. A categoria personalizada pertence exclusivamente ao criador e é automaticamente marcada como `padrao = false`.
+
+**Persona principal:** Rafael (usuário experiente que quer granularidade na classificação)
+
+### 🔌 Especificação
+
+- **Endpoint:** `POST /api/categorias`
+- **Autenticação:** ✅ Token JWT obrigatório
+- **Corpo da requisição:** `nome`, `tipo` (receita, despesa, ambos), `icone` (opcional)
+
+### ✅ Critérios de Aceitação
+
+#### CA-01 — Criação bem-sucedida com dados válidos
+
+```gherkin
+Dado que estou autenticado
+  E informo nome válido e tipo válido
+Quando envio a requisição de criação
+Então a resposta deve ter status 201
+  E o corpo deve conter id, nome, tipo, icone, padrao e criadoEm
+  E o campo padrao deve ser false
+  E a categoria deve pertencer ao usuário autenticado
+```
+
+#### CA-02 — Criação com ícone opcional
+
+```gherkin
+Dado que estou autenticado
+  E informo nome e tipo válidos sem enviar ícone
+Quando envio a requisição de criação
+Então a resposta deve ter status 201
+  E o campo icone deve ser null ou ausente
+```
+
+#### CA-03 — Tipo deve ser receita, despesa ou ambos
+
+```gherkin
+Dado que informo um tipo diferente de receita, despesa ou ambos
+Quando envio a requisição de criação
+Então a resposta deve ter status 400
+  E a resposta deve indicar erro de validação no campo tipo
+```
+
+#### CA-04 — Nome obrigatório
+
+```gherkin
+Dado que envio a requisição sem o campo nome
+Quando envio a requisição de criação
+Então a resposta deve ter status 400
+  E a resposta deve indicar campo obrigatório ausente
+```
+
+#### CA-05 — Campo padrao é definido automaticamente como false
+
+```gherkin
+Dado que envio a requisição com padrao = true no corpo
+Quando a categoria é criada
+Então o campo padrao deve ser false independentemente do valor enviado
+```
+
+#### CA-06 — Sem autenticação
+
+```gherkin
+Dado que envio a requisição sem token
+Quando envio a requisição de criação
+Então a resposta deve ter status 401
+  E o código do erro deve ser "TOKEN_AUSENTE"
+```
+
+### 📚 Regras de Negócio Cobertas
+
+| ID | Descrição |
+|---|---|
+| RK-010 | Campos obrigatórios: nome e tipo |
+| RK-011 | Tipos permitidos: receita, despesa, ambos |
+| RK-012 | Ícone é opcional |
+| RK-013 | Campo padrao sempre false para categorias criadas pelo usuário |
+| RK-014 | Categoria personalizada vinculada ao usuário autenticado |
+| RG-008 | Rotas protegidas exigem token JWT válido |
+| RG-009 | Token ausente retorna 401 |
+| RG-014 | Campos obrigatórios validados primeiro |
+
+### 🏷️ Labels para a Issue
+
+- `epic:categorias`
+- `tipo:api`
+- `tipo:testes`
+- `fase-2`
+- `prioridade:alta`
+
+### ✔️ Definition of Done
+
+- [x] Endpoint `POST /api/categorias` implementado
+- [x] Validações de nome e tipo funcionando
+- [x] Campo padrao definido automaticamente como false
+- [x] Categoria vinculada ao usuário autenticado (req.usuarioId)
+- [x] Todos os critérios de aceitação passando
+- [x] Testes automatizados escritos e passando
+- [x] Documentação Swagger atualizada
+- [x] Código revisado via Pull Request
+- [x] Branch mergeada na `main`
+
+### 📌 Observações
+
+- Usuário **não pode criar categorias padrão** — apenas o seed do sistema faz isso
+- Não há validação de nome duplicado entre categorias personalizadas (o mesmo usuário pode ter duas categorias com o mesmo nome)
+- O campo `icone` é uma string livre, sem validação de formato nesta fase
+
+---
+
+## US-017 — Consultar categoria
+
+![Épico](https://img.shields.io/badge/épico-EP--004-green)
+![Prioridade](https://img.shields.io/badge/prioridade-alta-yellow)
+![Fase](https://img.shields.io/badge/fase-2-purple)
+
+### 📖 Narrativa
+
+> **Como** usuária autenticada no Provus Finance,
+> **Quero** consultar os detalhes de uma categoria específica por ID,
+> **Para que** eu possa verificar suas informações antes de usá-la em uma transação.
+
+### 🎯 Contexto
+
+A consulta individual permite verificar os detalhes de uma categoria antes de associá-la a uma transação. Categorias padrão são acessíveis por qualquer usuário autenticado, enquanto categorias personalizadas só podem ser consultadas pelo seu criador.
+
+**Persona principal:** Sofia (quer transparência sobre as categorias disponíveis)
+
+### 🔌 Especificação
+
+- **Endpoint:** `GET /api/categorias/:id`
+- **Autenticação:** ✅ Token JWT obrigatório
+- **Path param:** `id` — ID da categoria
+
+### ✅ Critérios de Aceitação
+
+#### CA-01 — Consulta de categoria padrão por qualquer usuário
+
+```gherkin
+Dado que estou autenticado
+  E informo o ID de uma categoria padrão
+Quando consulto GET /api/categorias/:id
+Então a resposta deve ter status 200
+  E o corpo deve conter id, nome, tipo, icone, padrao e criadoEm
+  E o campo padrao deve ser true
+```
+
+#### CA-02 — Consulta de categoria personalizada pelo criador
+
+```gherkin
+Dado que estou autenticado
+  E informo o ID de uma categoria personalizada que eu criei
+Quando consulto GET /api/categorias/:id
+Então a resposta deve ter status 200
+  E o corpo deve conter os dados da categoria
+  E o campo padrao deve ser false
+```
+
+#### CA-03 — Categoria personalizada de outro usuário retorna 404
+
+```gherkin
+Dado que estou autenticado
+  E informo o ID de uma categoria personalizada de outro usuário
+Quando consulto GET /api/categorias/:id
+Então a resposta deve ter status 404
+  E o código do erro deve ser "CATEGORIA_NAO_ENCONTRADA"
+  E nenhuma informação da categoria alheia deve ser exposta
+```
+
+#### CA-04 — Categoria inexistente retorna 404
+
+```gherkin
+Dado que informo um ID que não existe no sistema
+Quando consulto GET /api/categorias/:id
+Então a resposta deve ter status 404
+  E o código do erro deve ser "CATEGORIA_NAO_ENCONTRADA"
+```
+
+#### CA-05 — Sem autenticação
+
+```gherkin
+Dado que envio a requisição sem token
+Quando consulto GET /api/categorias/:id
+Então a resposta deve ter status 401
+  E o código do erro deve ser "TOKEN_AUSENTE"
+```
+
+### 📚 Regras de Negócio Cobertas
+
+| ID | Descrição |
+|---|---|
+| RK-033 | Categoria padrão acessível por qualquer usuário autenticado |
+| RK-034 | Categoria personalizada acessível apenas pelo criador |
+| RK-035 | Categoria inexistente retorna 404 |
+| RK-036 | Consulta exige autenticação |
+| RG-008 | Rotas protegidas exigem token JWT válido |
+| RG-009 | Token ausente retorna 401 |
+| RG-012 | Usuário só acessa seus próprios recursos |
+
+### 🏷️ Labels para a Issue
+
+- `epic:categorias`
+- `tipo:api`
+- `tipo:testes`
+- `fase-2`
+- `prioridade:alta`
+
+### ✔️ Definition of Done
+
+- [x] Endpoint `GET /api/categorias/:id` implementado
+- [x] Categorias padrão acessíveis por todos os usuários autenticados
+- [x] Categorias personalizadas acessíveis apenas pelo criador
+- [x] 404 para categoria inexistente ou de outro usuário
+- [x] Todos os critérios de aceitação passando
+- [x] Testes automatizados escritos e passando
+- [x] Documentação Swagger atualizada
+- [x] Código revisado via Pull Request
+- [x] Branch mergeada na `main`
+
+### 📌 Observações
+
+- Categorias padrão são **compartilhadas** — todos os usuários autenticados podem consultá-las
+- Categorias personalizadas de outros usuários retornam 404 (não 403) para **não revelar a existência** do recurso
+
+---
+
+## US-018 — Atualizar categoria personalizada
+
+![Épico](https://img.shields.io/badge/épico-EP--004-green)
+![Prioridade](https://img.shields.io/badge/prioridade-media-green)
+![Fase](https://img.shields.io/badge/fase-2-purple)
+
+### 📖 Narrativa
+
+> **Como** usuário autenticado no Provus Finance,
+> **Quero** atualizar o nome e/ou ícone de uma categoria personalizada que eu criei,
+> **Para que** eu possa corrigir ou melhorar a classificação sem perder o histórico de transações associadas.
+
+### 🎯 Contexto
+
+Com o tempo, o usuário pode querer renomear ou trocar o ícone de uma categoria personalizada. O **tipo é imutável** para preservar a consistência das transações já classificadas. Categorias padrão do sistema **não podem ser alteradas** por nenhum usuário.
+
+**Persona principal:** Rafael (mantém suas categorias organizadas e atualizadas)
+
+### 🔌 Especificação
+
+- **Endpoint:** `PUT /api/categorias/:id`
+- **Autenticação:** ✅ Token JWT obrigatório
+- **Path param:** `id` — ID da categoria
+- **Corpo da requisição:** `nome` e/ou `icone` (atualização parcial)
+
+### ✅ Critérios de Aceitação
+
+#### CA-01 — Atualização bem-sucedida de nome e ícone
+
+```gherkin
+Dado que estou autenticado
+  E informo o ID de uma categoria personalizada que eu criei
+  E informo novo nome e novo ícone
+Quando envio a requisição de atualização
+Então a resposta deve ter status 200
+  E o corpo deve conter os dados atualizados
+  E o campo atualizadoEm deve estar com timestamp recente
+```
+
+#### CA-02 — Atualização parcial apenas do nome
+
+```gherkin
+Dado que estou autenticado
+  E informo apenas o novo nome
+Quando envio a atualização
+Então a resposta deve ter status 200
+  E apenas o nome deve ser alterado
+  E o ícone deve permanecer inalterado
+```
+
+#### CA-03 — Tipo é imutável
+
+```gherkin
+Dado que estou autenticado
+  E tento alterar o campo tipo de uma categoria personalizada
+Quando envio a atualização
+Então o campo tipo deve permanecer inalterado
+  Ou a resposta deve retornar status 400 indicando que o tipo não pode ser alterado
+```
+
+#### CA-04 — Tentativa de atualizar categoria padrão retorna 403
+
+```gherkin
+Dado que estou autenticado
+  E informo o ID de uma categoria padrão do sistema
+Quando envio a requisição de atualização
+Então a resposta deve ter status 403
+  E o código do erro deve ser "ACESSO_NEGADO"
+```
+
+#### CA-05 — Categoria personalizada de outro usuário retorna 404
+
+```gherkin
+Dado que estou autenticado
+  E informo o ID de uma categoria personalizada de outro usuário
+Quando envio a requisição de atualização
+Então a resposta deve ter status 404
+  E o código do erro deve ser "CATEGORIA_NAO_ENCONTRADA"
+```
+
+#### CA-06 — Categoria inexistente retorna 404
+
+```gherkin
+Dado que informo um ID que não existe no sistema
+Quando envio a requisição de atualização
+Então a resposta deve ter status 404
+  E o código do erro deve ser "CATEGORIA_NAO_ENCONTRADA"
+```
+
+#### CA-07 — Nome inválido na atualização
+
+```gherkin
+Dado que informo um nome em formato inválido ou vazio
+Quando envio a atualização
+Então a resposta deve ter status 400
+  E a resposta deve indicar o erro de validação
+```
+
+#### CA-08 — Sem autenticação
+
+```gherkin
+Dado que envio a requisição sem token
+Quando envio a requisição de atualização
+Então a resposta deve ter status 401
+  E o código do erro deve ser "TOKEN_AUSENTE"
+```
+
+### 📚 Regras de Negócio Cobertas
+
+| ID | Descrição |
+|---|---|
+| RK-037 | Campos atualizáveis: nome e ícone |
+| RK-038 | Atualização parcial é permitida |
+| RK-039 | Tipo é imutável após criação |
+| RK-040 | Categorias padrão não podem ser alteradas (403 ACESSO_NEGADO) |
+| RK-041 | Categoria personalizada só atualizada pelo criador |
+| RK-042 | Timestamp atualizadoEm é atualizado automaticamente |
+| RK-043 | Atualização retorna categoria atualizada |
+| RG-008 | Rotas protegidas exigem token JWT válido |
+| RG-009 | Token ausente retorna 401 |
+| RG-012 | Usuário só acessa seus próprios recursos |
+
+### 🏷️ Labels para a Issue
+
+- `epic:categorias`
+- `tipo:api`
+- `tipo:testes`
+- `fase-2`
+- `prioridade:media`
+
+### ✔️ Definition of Done
+
+- [x] Endpoint `PUT /api/categorias/:id` implementado
+- [x] Atualização parcial de nome e ícone funcionando
+- [x] Tipo imutável após criação
+- [x] 403 ao tentar atualizar categoria padrão
+- [x] 404 para categoria inexistente ou de outro usuário
+- [x] Todos os critérios de aceitação passando
+- [x] Testes automatizados escritos e passando
+- [x] Documentação Swagger atualizada
+- [x] Código revisado via Pull Request
+- [x] Branch mergeada na `main`
+
+### 📌 Observações
+
+- O **tipo não pode ser alterado** para preservar a consistência de transações já classificadas
+- Categorias padrão retornam **403** (e não 404) pois o recurso existe mas a operação não é permitida
+- Categorias personalizadas de outros usuários retornam **404** para não revelar existência
+
+---
+
+## US-019 — Excluir categoria personalizada
+
+![Épico](https://img.shields.io/badge/épico-EP--004-green)
+![Prioridade](https://img.shields.io/badge/prioridade-media-green)
+![Fase](https://img.shields.io/badge/fase-2-purple)
+
+### 📖 Narrativa
+
+> **Como** usuário autenticado no Provus Finance,
+> **Quero** excluir uma categoria personalizada que não utilizo mais,
+> **Para que** eu mantenha minha lista de categorias limpa e relevante.
+
+### 🎯 Contexto
+
+Categorias personalizadas que não são mais úteis podem ser removidas pelo criador. A exclusão é **hard delete** (permanente). Porém, se a categoria estiver associada a transações existentes, a exclusão é **bloqueada** para preservar a integridade dos dados. Categorias padrão do sistema **nunca podem ser excluídas**.
+
+**Persona principal:** Rafael (mantém suas categorias organizadas)
+
+### 🔌 Especificação
+
+- **Endpoint:** `DELETE /api/categorias/:id`
+- **Autenticação:** ✅ Token JWT obrigatório
+- **Path param:** `id` — ID da categoria
+
+### ✅ Critérios de Aceitação
+
+#### CA-01 — Exclusão bem-sucedida de categoria sem transações
+
+```gherkin
+Dado que estou autenticado
+  E informo o ID de uma categoria personalizada que eu criei
+  E a categoria não está associada a nenhuma transação
+Quando envio a requisição de exclusão
+Então a resposta deve ter status 204
+  E a resposta não deve conter corpo
+  E a categoria deve ser removida do banco
+```
+
+#### CA-02 — Exclusão bloqueada por transações vinculadas
+
+```gherkin
+Dado que estou autenticado
+  E a categoria personalizada está associada a transações existentes
+Quando envio a requisição de exclusão
+Então a resposta deve ter status 409
+  E o código do erro deve ser "CATEGORIA_EM_USO"
+  E a categoria deve permanecer intacta
+```
+
+#### CA-03 — Tentativa de excluir categoria padrão retorna 403
+
+```gherkin
+Dado que estou autenticado
+  E informo o ID de uma categoria padrão do sistema
+Quando envio a requisição de exclusão
+Então a resposta deve ter status 403
+  E o código do erro deve ser "ACESSO_NEGADO"
+```
+
+#### CA-04 — Categoria personalizada de outro usuário retorna 404
+
+```gherkin
+Dado que estou autenticado
+  E informo o ID de uma categoria personalizada de outro usuário
+Quando envio a requisição de exclusão
+Então a resposta deve ter status 404
+  E o código do erro deve ser "CATEGORIA_NAO_ENCONTRADA"
+```
+
+#### CA-05 — Categoria inexistente retorna 404
+
+```gherkin
+Dado que informo um ID que não existe no sistema
+Quando envio a requisição de exclusão
+Então a resposta deve ter status 404
+  E o código do erro deve ser "CATEGORIA_NAO_ENCONTRADA"
+```
+
+#### CA-06 — Sem autenticação
+
+```gherkin
+Dado que envio a requisição sem token
+Quando envio a requisição de exclusão
+Então a resposta deve ter status 401
+  E o código do erro deve ser "TOKEN_AUSENTE"
+```
+
+### 📚 Regras de Negócio Cobertas
+
+| ID | Descrição |
+|---|---|
+| RK-044 | Exclusão é hard delete (permanente) |
+| RK-045 | Exclusão bloqueada se categoria tem transações (409 CATEGORIA_EM_USO) |
+| RK-046 | Categorias padrão não podem ser excluídas (403 ACESSO_NEGADO) |
+| RK-047 | Categoria personalizada só excluída pelo criador |
+| RK-048 | Exclusão retorna 204 sem corpo |
+| RG-008 | Rotas protegidas exigem token JWT válido |
+| RG-009 | Token ausente retorna 401 |
+| RG-012 | Usuário só acessa seus próprios recursos |
+
+### 🏷️ Labels para a Issue
+
+- `epic:categorias`
+- `tipo:api`
+- `tipo:testes`
+- `fase-2`
+- `prioridade:media`
+
+### ✔️ Definition of Done
+
+- [x] Endpoint `DELETE /api/categorias/:id` implementado
+- [x] Hard delete para categorias personalizadas sem transações
+- [x] Bloqueio com 409 quando categoria tem transações vinculadas
+- [x] 403 ao tentar excluir categoria padrão
+- [x] 404 para categoria inexistente ou de outro usuário
+- [x] Todos os critérios de aceitação passando
+- [x] Testes automatizados escritos e passando
+- [x] Documentação Swagger atualizada
+- [x] Código revisado via Pull Request
+- [x] Branch mergeada na `main`
+
+### 📌 Observações
+
+- Diferente da exclusão de conta (US-005), aqui **não há cascata** — a exclusão é bloqueada se existem transações
+- Categorias padrão retornam **403** (e não 404) pois o recurso existe mas a operação não é permitida
+- Para remover uma categoria em uso, o usuário precisa primeiro reclassificar ou excluir as transações associadas
+
+---
+
+## 📊 Resumo de Cobertura
+
+### Estatísticas
+
+| Métrica | Valor |
+|---|---|
+| **Total de User Stories** | 5 |
+| **Total de Critérios de Aceitação** | 29 |
+| **Regras de negócio cobertas** | RK-010 a RK-048 + regras gerais |
+| **Endpoints implementados** | 5 |
+
+### Distribuição de Critérios de Aceitação
+
+```
+US-015 (Listar):      ███████   6 CAs
+US-016 (Criar):       ███████   6 CAs
+US-017 (Consultar):   ██████    5 CAs
+US-018 (Atualizar):   █████████ 8 CAs
+US-019 (Excluir):     ███████   6 CAs
+```
+
+### Cobertura por prioridade
+
+| Prioridade | User Stories |
+|---|---|
+| 🔴 **Crítica** | US-015 |
+| 🟡 **Alta** | US-016, US-017 |
+| 🟢 **Média** | US-018, US-019 |
+
+### Rastreabilidade futura
+
+Cada US vai gerar:
+- **1 issue** no GitHub Projects
+- **1 branch** (ex: `feat/us-015-listar-categorias`)
+- **1 Pull Request**
+- **Múltiplos casos de teste** na pasta `06-testes/`
+- **Testes automatizados** com identificadores rastreáveis
+
+---
+
+## 🔗 Documentos Relacionados
+
+- 📦 [Épicos da Fase 1](../04-epicos/epicos.md)
+- 📄 [Regras de Negócio](../02-regras-negocio/)
+- 📄 [Contratos da API](../03-arquitetura/api-contratos.md)
+- 📄 [Personas](../01-visao/personas.md)
+- 📄 [User Stories — EP-001](ep-001-usuarios.md)
+- 📄 [User Stories — EP-002](ep-002-autenticacao.md)
+- 📄 [User Stories — EP-003](ep-003-contas.md)
+
+---
+
+<div align="center">
+
+**← Voltar ao [README principal](../../README.md)**
+
+</div>

--- a/docs/06-testes/casos-teste-ep-004-categorias.md
+++ b/docs/06-testes/casos-teste-ep-004-categorias.md
@@ -1,0 +1,376 @@
+# ✅ Casos de Teste — EP-004: Gestão de Categorias
+
+> Casos de teste do Épico 4, elaborados com base nas User Stories de categorias e nas regras de negócio vigentes, mantendo rastreabilidade completa.
+
+---
+
+## 1. Objetivo
+
+Definir os cenários de teste do EP-004 para validar listagem, criação, consulta, atualização e exclusão de categorias (padrão e personalizadas).
+
+---
+
+## 2. Referências
+
+- `docs/05-user-stories/ep-004-categorias.md`
+- `docs/02-regras-negocio/regras-gerais.md`
+- `docs/03-arquitetura/api-contratos.md`
+- `docs/06-testes/estrategia-testes.md`
+- `docs/06-testes/plano-testes-fase-1.md`
+
+---
+
+## 3. Convenções
+
+- **ID do caso:** `CT-EP004-USXXX-YY`
+- **Tipo:** API (automatizável) + execução manual complementar
+- **Rastreabilidade obrigatória:** `US` + `RK/RG`
+- **Formato esperado de erro:** `{"erro":{"codigo":"...","mensagem":"..."}}`
+
+---
+
+## 4. Casos de teste
+
+### US-015 — Listar categorias (`GET /api/categorias`)
+
+#### CT-EP004-US015-01 — Listagem retorna categorias padrão e personalizadas
+- **Rastreabilidade:** US-015, RK-027, RK-028
+- **Prioridade:** Alta
+- **Pré-condições:** token JWT válido; usuário com categorias personalizadas criadas
+- **Passos:**
+  1. Enviar `GET /api/categorias` com token válido.
+- **Resultado esperado:**
+  - HTTP `200`
+  - Body contém categorias padrão e personalizadas do usuário
+  - Sem categorias personalizadas de outros usuários
+
+#### CT-EP004-US015-02 — Filtro por tipo (despesa)
+- **Rastreabilidade:** US-015, RK-029
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `GET /api/categorias?tipo=despesa`.
+- **Resultado esperado:**
+  - HTTP `200`
+  - Todas as categorias retornadas com tipo "despesa" ou "ambos"
+
+#### CT-EP004-US015-03 — Filtro por origem (padrao=true)
+- **Rastreabilidade:** US-015, RK-030
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `GET /api/categorias?padrao=true`.
+- **Resultado esperado:**
+  - HTTP `200`
+  - Todas as categorias retornadas com padrao = true
+
+#### CT-EP004-US015-04 — Usuário sem categorias personalizadas vê apenas padrão
+- **Rastreabilidade:** US-015, RK-027
+- **Prioridade:** Média
+- **Pré-condições:** usuário sem categorias personalizadas
+- **Passos:**
+  1. Enviar `GET /api/categorias` com token válido.
+- **Resultado esperado:**
+  - HTTP `200`
+  - Apenas as 13 categorias padrão retornadas
+
+#### CT-EP004-US015-05 — Cada categoria contém campos esperados
+- **Rastreabilidade:** US-015, RK-031
+- **Prioridade:** Média
+- **Passos:**
+  1. Enviar `GET /api/categorias` com token válido.
+  2. Inspecionar cada item do array.
+- **Resultado esperado:**
+  - Cada categoria contém id, nome, tipo, icone, padrao e criadoEm
+
+#### CT-EP004-US015-06 — Listagem sem token
+- **Rastreabilidade:** US-015, RK-032, RG-009
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `GET /api/categorias` sem header Authorization.
+- **Resultado esperado:**
+  - HTTP `401`
+  - `erro.codigo = TOKEN_AUSENTE`
+
+#### CT-EP004-US015-07 — Filtro por tipo (receita)
+- **Rastreabilidade:** US-015, RK-029
+- **Prioridade:** Média
+- **Passos:**
+  1. Enviar `GET /api/categorias?tipo=receita`.
+- **Resultado esperado:**
+  - HTTP `200`
+  - Todas as categorias retornadas com tipo "receita" ou "ambos"
+
+---
+
+### US-016 — Criar categoria personalizada (`POST /api/categorias`)
+
+#### CT-EP004-US016-01 — Criação com dados válidos
+- **Rastreabilidade:** US-016, RK-010, RK-013, RK-014
+- **Prioridade:** Alta
+- **Pré-condições:** token JWT válido
+- **Passos:**
+  1. Enviar `POST /api/categorias` com `nome`, `tipo` válidos.
+- **Resultado esperado:**
+  - HTTP `201`
+  - Body com `id`, `nome`, `tipo`, `icone`, `padrao`, `criadoEm`
+  - `padrao = false`
+
+#### CT-EP004-US016-02 — Criação com ícone opcional
+- **Rastreabilidade:** US-016, RK-012
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `POST /api/categorias` com `nome`, `tipo` e `icone`.
+- **Resultado esperado:**
+  - HTTP `201`
+  - `icone` presente no retorno
+
+#### CT-EP004-US016-03 — Criação sem ícone
+- **Rastreabilidade:** US-016, RK-012
+- **Prioridade:** Média
+- **Passos:**
+  1. Enviar `POST /api/categorias` sem campo `icone`.
+- **Resultado esperado:**
+  - HTTP `201`
+  - `icone` null ou ausente
+
+#### CT-EP004-US016-04 — Tipo inválido
+- **Rastreabilidade:** US-016, RK-011
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar requisição com `tipo` diferente de receita, despesa ou ambos.
+- **Resultado esperado:**
+  - HTTP `400`
+  - erro de validação no campo tipo
+
+#### CT-EP004-US016-05 — Nome ausente
+- **Rastreabilidade:** US-016, RK-010, RG-014
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar requisição sem campo `nome`.
+- **Resultado esperado:**
+  - HTTP `400`
+  - erro de obrigatoriedade para `nome`
+
+#### CT-EP004-US016-06 — Campo padrao ignorado (forçado false)
+- **Rastreabilidade:** US-016, RK-013
+- **Prioridade:** Média
+- **Passos:**
+  1. Enviar requisição com `padrao: true` no corpo.
+- **Resultado esperado:**
+  - HTTP `201`
+  - `padrao = false` independentemente do valor enviado
+
+#### CT-EP004-US016-07 — Criação sem token
+- **Rastreabilidade:** US-016, RG-009
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `POST /api/categorias` sem header Authorization.
+- **Resultado esperado:**
+  - HTTP `401`
+  - `erro.codigo = TOKEN_AUSENTE`
+
+#### CT-EP004-US016-08 — Aceitar todos os 3 tipos válidos
+- **Rastreabilidade:** US-016, RK-011
+- **Prioridade:** Alta
+- **Passos:**
+  1. Criar categoria para cada tipo: receita, despesa, ambos.
+- **Resultado esperado:**
+  - HTTP `201` para cada tipo
+
+---
+
+### US-017 — Consultar categoria (`GET /api/categorias/:id`)
+
+#### CT-EP004-US017-01 — Consulta de categoria padrão
+- **Rastreabilidade:** US-017, RK-033
+- **Prioridade:** Alta
+- **Pré-condições:** token JWT válido
+- **Passos:**
+  1. Enviar `GET /api/categorias/:id` com ID de categoria padrão.
+- **Resultado esperado:**
+  - HTTP `200`
+  - Body com `id`, `nome`, `tipo`, `icone`, `padrao`, `criadoEm`
+  - `padrao = true`
+
+#### CT-EP004-US017-02 — Consulta de categoria personalizada pelo criador
+- **Rastreabilidade:** US-017, RK-034
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `GET /api/categorias/:id` com ID de categoria personalizada própria.
+- **Resultado esperado:**
+  - HTTP `200`
+  - `padrao = false`
+
+#### CT-EP004-US017-03 — Categoria personalizada de outro usuário retorna 404
+- **Rastreabilidade:** US-017, RK-034, RG-012
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `GET /api/categorias/:id` com ID de categoria personalizada de outro usuário.
+- **Resultado esperado:**
+  - HTTP `404`
+  - `erro.codigo = CATEGORIA_NAO_ENCONTRADA`
+
+#### CT-EP004-US017-04 — Categoria inexistente retorna 404
+- **Rastreabilidade:** US-017, RK-035
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `GET /api/categorias/:id` com ID inexistente.
+- **Resultado esperado:**
+  - HTTP `404`
+  - `erro.codigo = CATEGORIA_NAO_ENCONTRADA`
+
+#### CT-EP004-US017-05 — Consulta sem token
+- **Rastreabilidade:** US-017, RK-036, RG-009
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `GET /api/categorias/:id` sem header Authorization.
+- **Resultado esperado:**
+  - HTTP `401`
+  - `erro.codigo = TOKEN_AUSENTE`
+
+---
+
+### US-018 — Atualizar categoria personalizada (`PUT /api/categorias/:id`)
+
+#### CT-EP004-US018-01 — Atualização completa de nome e ícone
+- **Rastreabilidade:** US-018, RK-037, RK-043
+- **Prioridade:** Alta
+- **Pré-condições:** token válido; categoria personalizada própria
+- **Passos:**
+  1. Enviar `PUT /api/categorias/:id` com novo `nome` e novo `icone`.
+- **Resultado esperado:**
+  - HTTP `200`
+  - dados atualizados retornados
+
+#### CT-EP004-US018-02 — Atualização parcial apenas do nome
+- **Rastreabilidade:** US-018, RK-038
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar atualização apenas com `nome`.
+- **Resultado esperado:**
+  - HTTP `200`
+  - apenas o nome alterado
+
+#### CT-EP004-US018-03 — Tipo é imutável
+- **Rastreabilidade:** US-018, RK-039
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar atualização tentando alterar o campo `tipo`.
+- **Resultado esperado:**
+  - campo tipo permanece inalterado
+  - ou HTTP `400` indicando que tipo não pode ser alterado
+
+#### CT-EP004-US018-04 — Tentativa de atualizar categoria padrão retorna 403
+- **Rastreabilidade:** US-018, RK-040
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `PUT /api/categorias/:id` com ID de categoria padrão.
+- **Resultado esperado:**
+  - HTTP `403`
+  - `erro.codigo = ACESSO_NEGADO`
+
+#### CT-EP004-US018-05 — Categoria personalizada de outro usuário retorna 404
+- **Rastreabilidade:** US-018, RK-041, RG-012
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `PUT /api/categorias/:id` com ID de categoria personalizada de outro usuário.
+- **Resultado esperado:**
+  - HTTP `404`
+  - `erro.codigo = CATEGORIA_NAO_ENCONTRADA`
+
+#### CT-EP004-US018-06 — Categoria inexistente retorna 404
+- **Rastreabilidade:** US-018, RK-041
+- **Prioridade:** Média
+- **Passos:**
+  1. Enviar `PUT /api/categorias/:id` com ID inexistente.
+- **Resultado esperado:**
+  - HTTP `404`
+  - `erro.codigo = CATEGORIA_NAO_ENCONTRADA`
+
+#### CT-EP004-US018-07 — Nome inválido na atualização
+- **Rastreabilidade:** US-018, RK-037
+- **Prioridade:** Média
+- **Passos:**
+  1. Enviar nome vazio ou inválido.
+- **Resultado esperado:**
+  - HTTP `400`
+  - erro de validação
+
+#### CT-EP004-US018-08 — Atualização sem token
+- **Rastreabilidade:** US-018, RG-009
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `PUT /api/categorias/:id` sem header Authorization.
+- **Resultado esperado:**
+  - HTTP `401`
+  - `erro.codigo = TOKEN_AUSENTE`
+
+---
+
+### US-019 — Excluir categoria personalizada (`DELETE /api/categorias/:id`)
+
+#### CT-EP004-US019-01 — Exclusão de categoria sem transações
+- **Rastreabilidade:** US-019, RK-044, RK-048
+- **Prioridade:** Alta
+- **Pré-condições:** token válido; categoria personalizada própria sem transações
+- **Passos:**
+  1. Enviar `DELETE /api/categorias/:id` com ID de categoria personalizada sem transações.
+- **Resultado esperado:**
+  - HTTP `204`
+  - sem body de resposta
+
+#### CT-EP004-US019-02 — Exclusão bloqueada por transações vinculadas
+- **Rastreabilidade:** US-019, RK-045
+- **Prioridade:** Alta
+- **Pré-condições:** categoria personalizada com transações associadas
+- **Passos:**
+  1. Enviar `DELETE /api/categorias/:id` com ID de categoria em uso.
+- **Resultado esperado:**
+  - HTTP `409`
+  - `erro.codigo = CATEGORIA_EM_USO`
+
+#### CT-EP004-US019-03 — Tentativa de excluir categoria padrão retorna 403
+- **Rastreabilidade:** US-019, RK-046
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `DELETE /api/categorias/:id` com ID de categoria padrão.
+- **Resultado esperado:**
+  - HTTP `403`
+  - `erro.codigo = ACESSO_NEGADO`
+
+#### CT-EP004-US019-04 — Categoria personalizada de outro usuário retorna 404
+- **Rastreabilidade:** US-019, RK-047, RG-012
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `DELETE /api/categorias/:id` com ID de categoria personalizada de outro usuário.
+- **Resultado esperado:**
+  - HTTP `404`
+  - `erro.codigo = CATEGORIA_NAO_ENCONTRADA`
+
+#### CT-EP004-US019-05 — Exclusão sem token
+- **Rastreabilidade:** US-019, RG-009
+- **Prioridade:** Alta
+- **Passos:**
+  1. Enviar `DELETE /api/categorias/:id` sem header Authorization.
+- **Resultado esperado:**
+  - HTTP `401`
+  - `erro.codigo = TOKEN_AUSENTE`
+
+---
+
+## 5. Resumo de cobertura
+
+- **Total de casos:** 33
+- **Distribuição por US:**
+  - US-015: 7
+  - US-016: 8
+  - US-017: 5
+  - US-018: 8
+  - US-019: 5
+
+---
+
+## 6. Próximos passos
+
+1. Classificar quais casos entram primeiro na automação (`tipo:testes`) por risco.
+2. Selecionar amostra crítica para execução manual exploratória com evidência.
+3. Evoluir para matriz de rastreabilidade de execução (`planejado`, `executado`, `aprovado`, `reprovado`).


### PR DESCRIPTION
## Summary
  - Implementa os 5 endpoints de gestão de categorias (EP-004)
  - Migration com tabela categorias + seed de 13 categorias padrão (9
  despesa, 4 receita)
  - Categorias padrão protegidas contra edição (403) e exclusão (403)
  - Exclusão bloqueada quando há transações vinculadas (409)
  - 33 testes automatizados cobrindo fluxo feliz, validações, proteção e
  isolamento
  - Swagger e documentação completa

  ## Endpoints
  | Método | Rota | US |
  |---|---|---|
  | GET | /api/categorias | US-015 |
  | POST | /api/categorias | US-016 |
  | GET | /api/categorias/:id | US-017 |
  | PUT | /api/categorias/:id | US-018 |
  | DELETE | /api/categorias/:id | US-019 |

  ## Test plan
  - [x] 124 testes passando (91 anteriores + 33 novos)
  - [x] npm test executa sem falhas
  - [x] Migration + seed aplica corretamente
  - [x] Swagger visível em /api-docs
  - [x] docs/05-user-stories/ep-004-categorias.md criado
  - [x] docs/06-testes/casos-teste-ep-004-categorias.md criado

  Closes #63, #64, #65, #66, #67, #68, #69