### PR TITLE
docs(testes): reescreve casos de teste no formato ISO-29119-3

### DIFF
--- a/docs/06-testes/casos-teste-ep-001-usuarios.md
+++ b/docs/06-testes/casos-teste-ep-001-usuarios.md
@@ -1,16 +1,16 @@
-# ✅ Casos de Teste — EP-001: Gestão de Usuários
+# Casos de Teste — EP-001: Gestao de Usuarios
 
-> Casos de teste do Épico 1, elaborados com base nas User Stories de usuários e nas regras de negócio vigentes, mantendo rastreabilidade completa.
+> Casos de teste do Epico 1, elaborados com base nas User Stories de usuarios e nas regras de negocio vigentes, mantendo rastreabilidade completa conforme ISO/IEC/IEEE 29119-3.
 
 ---
 
 ## 1. Objetivo
 
-Definir os cenários de teste do EP-001 para validar cadastro, consulta de perfil, atualização de dados, alteração de senha e exclusão de conta.
+Definir os cenarios de teste do EP-001 para validar cadastro, consulta de perfil, atualizacao de dados, alteracao de senha e exclusao de conta.
 
 ---
 
-## 2. Referências
+## 2. Referencias
 
 - `docs/05-user-stories/ep-001-usuarios.md`
 - `docs/02-regras-negocio/regras-usuario.md`
@@ -21,402 +21,755 @@ Definir os cenários de teste do EP-001 para validar cadastro, consulta de perfi
 
 ---
 
-## 3. Convenções
+## 3. Convencoes
 
 - **ID do caso:** `CT-EP001-USXXX-YY`
-- **Tipo:** API (automatizável) + execução manual complementar
-- **Rastreabilidade obrigatória:** `US` + `RU/RG`
+- **Tipo:** API (automatizavel) + execucao manual complementar
+- **Rastreabilidade obrigatoria:** `US` + `RU/RG`
 - **Formato esperado de erro:** `{"erro":{"codigo":"...","mensagem":"..."}}`
 
 ---
 
 ## 4. Casos de teste
 
-### US-001 — Cadastrar novo usuário (`POST /api/usuarios`)
+### US-001 — Cadastrar novo usuario (`POST /api/usuarios`)
 
-#### CT-EP001-US001-01 — Cadastro com dados válidos
-- **Rastreabilidade:** US-001, RU-001, RU-002, RU-005, RU-006, RG-001, RG-004
-- **Prioridade:** Alta
-- **Pré-condições:** e-mail ainda não cadastrado
-- **Passos:**
-  1. Enviar `POST /api/usuarios` com `nome`, `email`, `senha` válidos.
-- **Resultado esperado:**
-  - HTTP `201`
-  - Body com `id`, `nome`, `email`, `criadoEm`, `atualizadoEm`
-  - Sem `senha` ou `senha_hash`
+#### CT-EP001-US001-01 — Cadastro com dados validos
 
-#### CT-EP001-US001-02 — Cadastro com e-mail já existente
-- **Rastreabilidade:** US-001, RU-003
-- **Prioridade:** Alta
-- **Pré-condições:** usuário pré-existente com o e-mail informado
-- **Passos:**
-  1. Repetir cadastro com e-mail já cadastrado.
-- **Resultado esperado:**
-  - HTTP `409`
-  - `erro.codigo = EMAIL_JA_CADASTRADO`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-01 |
+| **Titulo** | Validar que um novo usuario e cadastrado com sucesso ao enviar nome, email e senha validos |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-001, RU-001, RU-002, RU-005, RU-006, RG-001, RG-004 |
+| **Pre-Condicoes** | - Email informado ainda nao cadastrado no sistema |
 
-#### CT-EP001-US001-03 — Cadastro sem nome
-- **Rastreabilidade:** US-001, RU-001, RG-014, RG-017
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição sem campo `nome`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de obrigatoriedade/validação para `nome`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com `nome`, `email` e `senha` validos | HTTP `201` |
+| 2 | Inspecionar body da resposta | Body contem `id`, `nome`, `email`, `criadoEm`, `atualizadoEm` e nao contem `senha` ou `senha_hash` |
 
-#### CT-EP001-US001-04 — Cadastro sem e-mail
-- **Rastreabilidade:** US-001, RU-001, RG-014, RG-017
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição sem campo `email`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de obrigatoriedade/validação para `email`
-
-#### CT-EP001-US001-05 — Cadastro sem senha
-- **Rastreabilidade:** US-001, RU-001, RG-014, RG-017
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição sem campo `senha`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de obrigatoriedade/validação para `senha`
-
-#### CT-EP001-US001-06 — E-mail com formato inválido
-- **Rastreabilidade:** US-001, RU-008, RU-011, RG-021
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar e-mail em formato inválido.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de formato/validação de e-mail
-
-#### CT-EP001-US001-07 — E-mail acima do limite
-- **Rastreabilidade:** US-001, RU-009
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar e-mail com mais de 254 caracteres.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de validação de tamanho
-
-#### CT-EP001-US001-08 — Senha abaixo do mínimo
-- **Rastreabilidade:** US-001, RU-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar senha com menos de 8 caracteres.
-- **Resultado esperado:**
-  - HTTP `400`
-  - detalhe de regra de senha não atendida
-
-#### CT-EP001-US001-09 — Senha sem maiúscula
-- **Rastreabilidade:** US-001, RU-014
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar senha sem letra maiúscula.
-- **Resultado esperado:**
-  - HTTP `400`
-
-#### CT-EP001-US001-10 — Senha sem minúscula
-- **Rastreabilidade:** US-001, RU-014
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar senha sem letra minúscula.
-- **Resultado esperado:**
-  - HTTP `400`
-
-#### CT-EP001-US001-11 — Senha sem número
-- **Rastreabilidade:** US-001, RU-014
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar senha sem dígito.
-- **Resultado esperado:**
-  - HTTP `400`
-
-#### CT-EP001-US001-12 — E-mail normalizado para minúsculas
-- **Rastreabilidade:** US-001, RU-010, RG-020
-- **Prioridade:** Média
-- **Passos:**
-  1. Cadastrar usuário com e-mail em caixa mista.
-- **Resultado esperado:**
-  - resposta/persistência com e-mail em minúsculas
-
-#### CT-EP001-US001-13 — Nome com espaços normalizados
-- **Rastreabilidade:** US-001, RU-020, RG-016
-- **Prioridade:** Média
-- **Passos:**
-  1. Cadastrar usuário com nome contendo múltiplos espaços.
-- **Resultado esperado:**
-  - nome retornado sem espaços excedentes
-
-#### CT-EP001-US001-14 — Nome inválido (somente números)
-- **Rastreabilidade:** US-001, RU-019
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar `nome` composto apenas por números.
-- **Resultado esperado:**
-  - HTTP `400`
+| **Pos-Condicoes** | - Usuario persistido no banco de dados com senha armazenada como hash |
 
 ---
 
-### US-002 — Consultar próprio perfil (`GET /api/usuarios/me`)
+#### CT-EP001-US001-02 — Cadastro com e-mail ja existente
 
-#### CT-EP001-US002-01 — Consulta com token válido
-- **Rastreabilidade:** US-002, RU-028, RU-029, RG-008
-- **Prioridade:** Alta
-- **Pré-condições:** token JWT válido
-- **Passos:**
-  1. Chamar `GET /api/usuarios/me` com header `Authorization: Bearer <token>`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - retorno dos dados do próprio usuário
-  - sem dados sensíveis
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-02 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando o e-mail ja esta em uso por outro usuario |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-001, RU-003 |
+| **Pre-Condicoes** | - Usuario pre-existente cadastrado com o e-mail que sera informado |
 
-#### CT-EP001-US002-02 — Consulta sem token
-- **Rastreabilidade:** US-002, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar endpoint sem header `Authorization`.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com e-mail ja cadastrado | HTTP `409` com `erro.codigo = EMAIL_JA_CADASTRADO` |
 
-#### CT-EP001-US002-03 — Consulta com token inválido
-- **Rastreabilidade:** US-002, RG-010
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar endpoint com token malformado/inválido.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_INVALIDO`
+| **Pos-Condicoes** | - Usuario original permanece inalterado no banco de dados |
+
+---
+
+#### CT-EP001-US001-03 — Cadastro sem campo nome
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-03 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando o campo nome esta ausente |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-001, RU-001, RG-014, RG-017 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` sem o campo `nome` | HTTP `400` com detalhes de obrigatoriedade/validacao para o campo `nome` |
+
+| **Pos-Condicoes** | - Nenhum usuario criado no banco de dados |
+
+---
+
+#### CT-EP001-US001-04 — Cadastro sem campo email
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-04 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando o campo email esta ausente |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-001, RU-001, RG-014, RG-017 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` sem o campo `email` | HTTP `400` com detalhes de obrigatoriedade/validacao para o campo `email` |
+
+| **Pos-Condicoes** | - Nenhum usuario criado no banco de dados |
+
+---
+
+#### CT-EP001-US001-05 — Cadastro sem campo senha
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-05 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando o campo senha esta ausente |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-001, RU-001, RG-014, RG-017 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` sem o campo `senha` | HTTP `400` com detalhes de obrigatoriedade/validacao para o campo `senha` |
+
+| **Pos-Condicoes** | - Nenhum usuario criado no banco de dados |
+
+---
+
+#### CT-EP001-US001-06 — E-mail com formato invalido (sem @)
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-06 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando o e-mail possui formato invalido |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-001, RU-008, RU-011, RG-021 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com e-mail em formato invalido (ex.: sem `@`) | HTTP `400` com erro de formato/validacao de e-mail |
+
+| **Pos-Condicoes** | - Nenhum usuario criado no banco de dados |
+
+---
+
+#### CT-EP001-US001-07 — E-mail acima do limite de 254 caracteres
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-07 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando o e-mail excede 254 caracteres |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-001, RU-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com e-mail contendo mais de 254 caracteres | HTTP `400` com erro de validacao de tamanho |
+
+| **Pos-Condicoes** | - Nenhum usuario criado no banco de dados |
+
+---
+
+#### CT-EP001-US001-08 — Senha com menos de 8 caracteres
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-08 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando a senha possui menos de 8 caracteres |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-001, RU-012 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com senha de menos de 8 caracteres | HTTP `400` com detalhe de regra de senha nao atendida |
+
+| **Pos-Condicoes** | - Nenhum usuario criado no banco de dados |
+
+---
+
+#### CT-EP001-US001-09 — Senha sem letra maiuscula
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-09 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando a senha nao contem letra maiuscula |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-001, RU-014 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com senha sem letra maiuscula | HTTP `400` com erro de complexidade de senha |
+
+| **Pos-Condicoes** | - Nenhum usuario criado no banco de dados |
+
+---
+
+#### CT-EP001-US001-10 — Senha sem letra minuscula
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-10 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando a senha nao contem letra minuscula |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-001, RU-014 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com senha sem letra minuscula | HTTP `400` com erro de complexidade de senha |
+
+| **Pos-Condicoes** | - Nenhum usuario criado no banco de dados |
+
+---
+
+#### CT-EP001-US001-11 — Senha sem digito numerico
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-11 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando a senha nao contem digito numerico |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-001, RU-014 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com senha sem nenhum digito numerico | HTTP `400` com erro de complexidade de senha |
+
+| **Pos-Condicoes** | - Nenhum usuario criado no banco de dados |
+
+---
+
+#### CT-EP001-US001-12 — E-mail normalizado para minusculas
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-12 |
+| **Titulo** | Validar que o sistema normaliza o e-mail para letras minusculas ao cadastrar usuario |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-001, RU-010, RG-020 |
+| **Pre-Condicoes** | - Email informado ainda nao cadastrado no sistema |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com e-mail em caixa mista (ex.: `User@Email.COM`) | HTTP `201` |
+| 2 | Inspecionar campo `email` na resposta | Email retornado inteiramente em letras minusculas |
+
+| **Pos-Condicoes** | - Usuario persistido com email normalizado em minusculas |
+
+---
+
+#### CT-EP001-US001-13 — Nome com espacos normalizados
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-13 |
+| **Titulo** | Validar que o sistema remove espacos excedentes do nome ao cadastrar usuario |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-001, RU-020, RG-016 |
+| **Pre-Condicoes** | - Email informado ainda nao cadastrado no sistema |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com nome contendo multiplos espacos consecutivos | HTTP `201` |
+| 2 | Inspecionar campo `nome` na resposta | Nome retornado sem espacos excedentes (trim + colapsar espacos internos) |
+
+| **Pos-Condicoes** | - Usuario persistido com nome normalizado |
+
+---
+
+#### CT-EP001-US001-14 — Nome composto apenas por numeros
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US001-14 |
+| **Titulo** | Validar que o sistema rejeita cadastro quando o nome e composto apenas por numeros |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-001, RU-019 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/usuarios` com `nome` contendo apenas digitos (ex.: `12345`) | HTTP `400` com erro de validacao de nome |
+
+| **Pos-Condicoes** | - Nenhum usuario criado no banco de dados |
+
+---
+
+### US-002 — Consultar proprio perfil (`GET /api/usuarios/me`)
+
+#### CT-EP001-US002-01 — Consulta com token valido
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US002-01 |
+| **Titulo** | Validar que o sistema retorna os dados do perfil do usuario autenticado com token valido |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-002, RU-028, RU-029, RG-008 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/usuarios/me` com header `Authorization: Bearer <token>` | HTTP `200` |
+| 2 | Inspecionar body da resposta | Body contem `id`, `nome`, `email`, `criadoEm`, `atualizadoEm` e nao contem `senha` ou `senha_hash` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no estado do sistema |
+
+---
+
+#### CT-EP001-US002-02 — Consulta sem token de autenticacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US002-02 |
+| **Titulo** | Validar que o sistema rejeita consulta de perfil quando o header Authorization esta ausente |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-002, RG-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/usuarios/me` sem header `Authorization` | HTTP `401` com `erro.codigo = TOKEN_AUSENTE` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no estado do sistema |
+
+---
+
+#### CT-EP001-US002-03 — Consulta com token invalido
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US002-03 |
+| **Titulo** | Validar que o sistema rejeita consulta de perfil quando o token JWT e malformado ou invalido |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-002, RG-010 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/usuarios/me` com token malformado ou invalido | HTTP `401` com `erro.codigo = TOKEN_INVALIDO` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no estado do sistema |
+
+---
 
 #### CT-EP001-US002-04 — Consulta com token expirado
-- **Rastreabilidade:** US-002, RG-011
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar endpoint com token expirado.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_EXPIRADO`
 
-#### CT-EP001-US002-05 — Verificar não exposição de dados sensíveis
-- **Rastreabilidade:** US-002, RG-004
-- **Prioridade:** Média
-- **Passos:**
-  1. Realizar consulta de perfil válida.
-  2. Inspecionar resposta.
-- **Resultado esperado:**
-  - ausência de `senha` e `senha_hash`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US002-04 |
+| **Titulo** | Validar que o sistema rejeita consulta de perfil quando o token JWT esta expirado |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-002, RG-011 |
+| **Pre-Condicoes** | - Token JWT com data de expiracao no passado |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/usuarios/me` com token expirado | HTTP `401` com `erro.codigo = TOKEN_EXPIRADO` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no estado do sistema |
+
+---
+
+#### CT-EP001-US002-05 — Nao exposicao de dados sensiveis no perfil
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US002-05 |
+| **Titulo** | Validar que a resposta da consulta de perfil nao expoe senha, hash ou outros dados sensiveis |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-002, RG-004 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/usuarios/me` com token valido | HTTP `200` |
+| 2 | Inspecionar todas as propriedades do body da resposta | Ausencia total de campos `senha`, `senha_hash` ou qualquer dado sensivel |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no estado do sistema |
 
 ---
 
 ### US-003 — Atualizar dados do perfil (`PUT /api/usuarios/me`)
 
-#### CT-EP001-US003-01 — Atualização completa de nome e e-mail
-- **Rastreabilidade:** US-003, RU-031, RU-036
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; novo e-mail disponível
-- **Passos:**
-  1. Enviar `PUT /api/usuarios/me` com novo `nome` e novo `email`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - dados atualizados retornados
+#### CT-EP001-US003-01 — Atualizacao completa de nome e e-mail
 
-#### CT-EP001-US003-02 — Atualização parcial apenas de nome
-- **Rastreabilidade:** US-003, RU-032
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar atualização apenas com `nome`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - apenas o nome alterado
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US003-01 |
+| **Titulo** | Validar que o sistema atualiza nome e e-mail do usuario autenticado com dados validos |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-003, RU-031, RU-036 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Novo e-mail nao utilizado por outro usuario |
 
-#### CT-EP001-US003-03 — E-mail em uso por outro usuário
-- **Rastreabilidade:** US-003, RU-033
-- **Prioridade:** Alta
-- **Passos:**
-  1. Atualizar para e-mail já usado por outro usuário.
-- **Resultado esperado:**
-  - HTTP `409`
-  - `erro.codigo = EMAIL_JA_CADASTRADO`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me` com novo `nome` e novo `email` | HTTP `200` com dados atualizados retornados no body |
 
-#### CT-EP001-US003-04 — Atualizar para o próprio e-mail
-- **Rastreabilidade:** US-003, RU-034
-- **Prioridade:** Média
-- **Passos:**
-  1. Atualizar mantendo o mesmo e-mail atual.
-- **Resultado esperado:**
-  - HTTP `200`
-  - sem conflito
+| **Pos-Condicoes** | - Nome e email do usuario alterados no banco de dados\n- Campo `atualizadoEm` reflete a data/hora da operacao |
 
-#### CT-EP001-US003-05 — Nome inválido na atualização
-- **Rastreabilidade:** US-003, RU-017, RU-019
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar nome inválido (ex.: somente números).
-- **Resultado esperado:**
-  - HTTP `400`
+---
 
-#### CT-EP001-US003-06 — Atualização sem token
-- **Rastreabilidade:** US-003, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar endpoint sem token.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+#### CT-EP001-US003-02 — Atualizacao parcial apenas do nome
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US003-02 |
+| **Titulo** | Validar que o sistema permite atualizar apenas o nome mantendo o e-mail inalterado |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-003, RU-032 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me` apenas com campo `nome` | HTTP `200` com nome atualizado e email inalterado |
+
+| **Pos-Condicoes** | - Apenas o nome do usuario alterado no banco de dados |
+
+---
+
+#### CT-EP001-US003-03 — E-mail em uso por outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US003-03 |
+| **Titulo** | Validar que o sistema rejeita atualizacao quando o novo e-mail ja esta em uso por outro usuario |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-003, RU-033 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Outro usuario cadastrado com o e-mail desejado |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me` com e-mail ja utilizado por outro usuario | HTTP `409` com `erro.codigo = EMAIL_JA_CADASTRADO` |
+
+| **Pos-Condicoes** | - Dados do usuario permanecem inalterados |
+
+---
+
+#### CT-EP001-US003-04 — Atualizar mantendo o proprio e-mail
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US003-04 |
+| **Titulo** | Validar que o sistema permite atualizacao enviando o proprio e-mail atual sem gerar conflito |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-003, RU-034 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me` com o mesmo e-mail atualmente cadastrado | HTTP `200` sem erro de conflito |
+
+| **Pos-Condicoes** | - Dados do usuario permanecem consistentes |
+
+---
+
+#### CT-EP001-US003-05 — Nome invalido (somente numeros) na atualizacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US003-05 |
+| **Titulo** | Validar que o sistema rejeita atualizacao quando o nome contem apenas numeros |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-003, RU-017, RU-019 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me` com `nome` composto apenas por numeros | HTTP `400` com erro de validacao de nome |
+
+| **Pos-Condicoes** | - Dados do usuario permanecem inalterados |
+
+---
+
+#### CT-EP001-US003-06 — Atualizacao sem token de autenticacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US003-06 |
+| **Titulo** | Validar que o sistema rejeita atualizacao de perfil quando o token esta ausente |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-003, RG-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me` sem header `Authorization` | HTTP `401` com `erro.codigo = TOKEN_AUSENTE` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no estado do sistema |
 
 ---
 
 ### US-004 — Alterar senha (`PUT /api/usuarios/me/senha`)
 
-#### CT-EP001-US004-01 — Alteração com senha atual correta
-- **Rastreabilidade:** US-004, RU-037, RU-038, RU-039, RU-042
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; senha atual conhecida
-- **Passos:**
-  1. Enviar `senhaAtual` correta e `senhaNova` válida.
-- **Resultado esperado:**
-  - HTTP `200`
-  - mensagem de sucesso
+#### CT-EP001-US004-01 — Alteracao de senha com senha atual correta e nova senha valida
 
-#### CT-EP001-US004-02 — Senha atual incorreta
-- **Rastreabilidade:** US-004, RU-038
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `senhaAtual` incorreta.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = CREDENCIAIS_INVALIDAS`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US004-01 |
+| **Titulo** | Validar que o sistema altera a senha quando a senha atual esta correta e a nova senha atende os requisitos |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-004, RU-037, RU-038, RU-039, RU-042 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Senha atual conhecida |
 
-#### CT-EP001-US004-03 — Nova senha igual à atual
-- **Rastreabilidade:** US-004, RU-040
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `senhaNova` igual à `senhaAtual`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - `erro.codigo = SENHA_IGUAL_ATUAL`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me/senha` com `senhaAtual` correta e `senhaNova` valida | HTTP `200` com mensagem de sucesso |
 
-#### CT-EP001-US004-04 — Nova senha inválida por regra de complexidade
-- **Rastreabilidade:** US-004, RU-039, RU-012, RU-013, RU-014
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar senha nova sem atender requisitos.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de validação de senha
-
-#### CT-EP001-US004-05 — Campo obrigatório ausente
-- **Rastreabilidade:** US-004, RU-037, RG-014
-- **Prioridade:** Média
-- **Passos:**
-  1. Omitir `senhaAtual` ou `senhaNova`.
-- **Resultado esperado:**
-  - HTTP `400`
-
-#### CT-EP001-US004-06 — Token permanece válido após alteração
-- **Rastreabilidade:** US-004, RU-041
-- **Prioridade:** Média
-- **Passos:**
-  1. Alterar senha com sucesso.
-  2. Reutilizar token atual em rota protegida.
-- **Resultado esperado:**
-  - acesso permitido
-
-#### CT-EP001-US004-07 — Não expor senha/hash na resposta
-- **Rastreabilidade:** US-004, RG-004
-- **Prioridade:** Média
-- **Passos:**
-  1. Executar alteração válida.
-  2. Inspecionar body.
-- **Resultado esperado:**
-  - sem dados sensíveis na resposta
+| **Pos-Condicoes** | - Senha do usuario atualizada no banco de dados (hash diferente)\n- Login com a nova senha funciona corretamente |
 
 ---
 
-### US-005 — Excluir própria conta (`DELETE /api/usuarios/me`)
+#### CT-EP001-US004-02 — Alteracao de senha com senha atual incorreta
 
-#### CT-EP001-US005-01 — Exclusão com senha correta
-- **Rastreabilidade:** US-005, RU-043, RU-044, RU-047
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; senha correta
-- **Passos:**
-  1. Enviar `DELETE /api/usuarios/me` com senha de confirmação.
-- **Resultado esperado:**
-  - HTTP `204`
-  - sem body de resposta
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US004-02 |
+| **Titulo** | Validar que o sistema rejeita alteracao de senha quando a senha atual informada esta incorreta |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-004, RU-038 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login |
 
-#### CT-EP001-US005-02 — Exclusão com senha incorreta
-- **Rastreabilidade:** US-005, RU-044
-- **Prioridade:** Alta
-- **Passos:**
-  1. Tentar excluir conta com senha incorreta.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = CREDENCIAIS_INVALIDAS`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me/senha` com `senhaAtual` incorreta | HTTP `401` com `erro.codigo = CREDENCIAIS_INVALIDAS` |
 
-#### CT-EP001-US005-03 — Exclusão sem senha de confirmação
-- **Rastreabilidade:** US-005, RU-044, RG-014
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar exclusão sem campo `senha`.
-- **Resultado esperado:**
-  - HTTP `400`
+| **Pos-Condicoes** | - Senha do usuario permanece inalterada |
 
-#### CT-EP001-US005-04 — Token antigo inválido após exclusão
-- **Rastreabilidade:** US-005, RU-048
-- **Prioridade:** Média
-- **Passos:**
-  1. Excluir usuário com sucesso.
-  2. Reutilizar token antigo.
-- **Resultado esperado:**
-  - HTTP `401`
+---
 
-#### CT-EP001-US005-05 — Reuso do e-mail após exclusão
-- **Rastreabilidade:** US-005, RU-049
-- **Prioridade:** Média
-- **Passos:**
-  1. Excluir conta.
-  2. Cadastrar novo usuário com o mesmo e-mail.
-- **Resultado esperado:**
-  - novo cadastro permitido
+#### CT-EP001-US004-03 — Nova senha igual a senha atual
 
-#### CT-EP001-US005-06 — Exclusão em cascata dos dados vinculados
-- **Rastreabilidade:** US-005, RU-045, RC-052, RK-053, RT-071
-- **Prioridade:** Alta
-- **Pré-condições:** usuário com dados relacionados
-- **Passos:**
-  1. Excluir usuário.
-  2. Validar ausência de dados vinculados conforme regra.
-- **Resultado esperado:**
-  - remoção em cascata conforme documentação
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US004-03 |
+| **Titulo** | Validar que o sistema rejeita alteracao quando a nova senha e identica a senha atual |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-004, RU-040 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Senha atual conhecida |
 
-#### CT-EP001-US005-07 — Atomicidade da exclusão
-- **Rastreabilidade:** US-005, RU-046, RG-038
-- **Prioridade:** Média
-- **Passos:**
-  1. Executar cenário controlado com falha intermediária.
-- **Resultado esperado:**
-  - nenhuma exclusão parcial
-  - consistência preservada
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me/senha` com `senhaNova` igual a `senhaAtual` | HTTP `400` com `erro.codigo = SENHA_IGUAL_ATUAL` |
+
+| **Pos-Condicoes** | - Senha do usuario permanece inalterada |
+
+---
+
+#### CT-EP001-US004-04 — Nova senha invalida por regra de complexidade
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US004-04 |
+| **Titulo** | Validar que o sistema rejeita alteracao quando a nova senha nao atende os requisitos de complexidade |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-004, RU-039, RU-012, RU-014 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Senha atual conhecida |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me/senha` com `senhaAtual` correta e `senhaNova` que nao atende requisitos de complexidade | HTTP `400` com erro de validacao de senha |
+
+| **Pos-Condicoes** | - Senha do usuario permanece inalterada |
+
+---
+
+#### CT-EP001-US004-05 — Campo obrigatorio ausente na alteracao de senha
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US004-05 |
+| **Titulo** | Validar que o sistema rejeita alteracao quando campo obrigatorio (senhaAtual ou senhaNova) esta ausente |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-004, RU-037, RG-014 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me/senha` omitindo `senhaAtual` ou `senhaNova` | HTTP `400` com erro de campo obrigatorio |
+
+| **Pos-Condicoes** | - Senha do usuario permanece inalterada |
+
+---
+
+#### CT-EP001-US004-06 — Token permanece valido apos alteracao de senha
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US004-06 |
+| **Titulo** | Validar que o token JWT atual permanece valido apos a alteracao de senha ser concluida |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-004, RU-041 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Senha atual conhecida |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me/senha` com dados validos | HTTP `200` com mensagem de sucesso |
+| 2 | Enviar `GET /api/usuarios/me` com o mesmo token utilizado no passo 1 | HTTP `200` com dados do perfil retornados normalmente |
+
+| **Pos-Condicoes** | - Token JWT continua funcional para rotas protegidas |
+
+---
+
+#### CT-EP001-US004-07 — Nao exposicao de senha ou hash na resposta de alteracao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US004-07 |
+| **Titulo** | Validar que a resposta da alteracao de senha nao expoe senha, hash ou dados sensiveis |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-004, RG-004 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Senha atual conhecida |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/usuarios/me/senha` com dados validos | HTTP `200` |
+| 2 | Inspecionar todas as propriedades do body da resposta | Ausencia total de campos `senha`, `senha_hash`, `senhaAtual`, `senhaNova` ou qualquer dado sensivel |
+
+| **Pos-Condicoes** | - Nenhuma exposicao de dados sensiveis |
+
+---
+
+### US-005 — Excluir propria conta (`DELETE /api/usuarios/me`)
+
+#### CT-EP001-US005-01 — Exclusao com senha de confirmacao correta
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US005-01 |
+| **Titulo** | Validar que o sistema exclui a conta do usuario quando a senha de confirmacao esta correta |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-005, RU-043, RU-044, RU-047 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Senha atual conhecida |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/usuarios/me` com `senha` de confirmacao correta | HTTP `204` sem body de resposta |
+
+| **Pos-Condicoes** | - Usuario removido do banco de dados\n- Dados vinculados removidos conforme regras de cascata |
+
+---
+
+#### CT-EP001-US005-02 — Exclusao com senha de confirmacao incorreta
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US005-02 |
+| **Titulo** | Validar que o sistema rejeita exclusao de conta quando a senha de confirmacao esta incorreta |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-005, RU-044 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/usuarios/me` com senha incorreta | HTTP `401` com `erro.codigo = CREDENCIAIS_INVALIDAS` |
+
+| **Pos-Condicoes** | - Usuario permanece inalterado no banco de dados |
+
+---
+
+#### CT-EP001-US005-03 — Exclusao sem senha de confirmacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US005-03 |
+| **Titulo** | Validar que o sistema rejeita exclusao de conta quando o campo senha esta ausente |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-005, RU-044, RG-014 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/usuarios/me` sem o campo `senha` | HTTP `400` com erro de campo obrigatorio |
+
+| **Pos-Condicoes** | - Usuario permanece inalterado no banco de dados |
+
+---
+
+#### CT-EP001-US005-04 — Token invalido apos exclusao da conta
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US005-04 |
+| **Titulo** | Validar que o token JWT utilizado para exclusao se torna invalido apos a conta ser removida |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-005, RU-048 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Senha atual conhecida |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/usuarios/me` com senha correta | HTTP `204` |
+| 2 | Enviar `GET /api/usuarios/me` com o token utilizado no passo 1 | HTTP `404` indicando que o usuario nao existe mais |
+
+| **Pos-Condicoes** | - Token nao permite mais acesso a nenhuma rota protegida |
+
+---
+
+#### CT-EP001-US005-05 — E-mail disponivel para recadastro apos exclusao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US005-05 |
+| **Titulo** | Validar que o e-mail fica disponivel para novo cadastro apos a exclusao da conta |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-005, RU-049 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Senha atual conhecida |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/usuarios/me` com senha correta | HTTP `204` |
+| 2 | Enviar `POST /api/usuarios` com o mesmo e-mail do usuario excluido | HTTP `201` com novo usuario cadastrado com sucesso |
+
+| **Pos-Condicoes** | - Novo usuario criado com o e-mail que anteriormente pertencia ao usuario excluido |
+
+---
+
+#### CT-EP001-US005-06 — Usuario removido do banco de dados apos exclusao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US005-06 |
+| **Titulo** | Validar que o registro do usuario e seus dados vinculados sao removidos do banco de dados apos exclusao |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-005, RU-045, RT-071 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema\n- Token JWT valido obtido via login\n- Senha atual conhecida |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/usuarios/me` com senha correta | HTTP `204` |
+| 2 | Consultar banco de dados diretamente para verificar ausencia do registro | Registro do usuario e dados vinculados ausentes no banco de dados |
+
+| **Pos-Condicoes** | - Nenhum registro do usuario remanescente no banco de dados |
+
+---
+
+#### CT-EP001-US005-07 — Atomicidade da operacao de exclusao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP001-US005-07 |
+| **Titulo** | Validar que a exclusao de conta e atomica (tudo ou nada), sem exclusao parcial em caso de falha |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-005, RU-046, RG-038 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema com dados vinculados\n- Token JWT valido obtido via login\n- Cenario controlado para simular falha intermediaria |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Executar cenario de exclusao com falha intermediaria simulada | Operacao falha sem exclusao parcial |
+| 2 | Verificar consistencia dos dados no banco de dados | Todos os dados do usuario permanecem intactos (nenhuma exclusao parcial) |
+
+| **Pos-Condicoes** | - Consistencia total do banco de dados preservada |
 
 ---
 
 ## 5. Resumo de cobertura
 
-- **Total de casos:** 39
-- **Distribuição por US:**
-  - US-001: 14
-  - US-002: 5
-  - US-003: 6
-  - US-004: 7
-  - US-005: 7
+| User Story | Descricao | Quantidade de CTs |
+|---|---|---|
+| US-001 | Cadastrar novo usuario | 14 |
+| US-002 | Consultar proprio perfil | 5 |
+| US-003 | Atualizar dados do perfil | 6 |
+| US-004 | Alterar senha | 7 |
+| US-005 | Excluir propria conta | 7 |
+| **Total** | | **39** |
 
 ---
 
-## 6. Próximos passos
+## 6. Proximos passos
 
-1. Classificar quais casos entram primeiro na automação (`tipo:testes`) por risco.
-2. Selecionar amostra crítica para execução manual exploratória com evidência.
-3. Evoluir para matriz de rastreabilidade de execução (`planejado`, `executado`, `aprovado`, `reprovado`).
+1. Classificar quais casos entram primeiro na automacao (`tipo:testes`) por risco.
+2. Selecionar amostra critica para execucao manual exploratoria com evidencia.
+3. Evoluir para matriz de rastreabilidade de execucao (`planejado`, `executado`, `aprovado`, `reprovado`).

--- a/docs/06-testes/casos-teste-ep-002-autenticacao.md
+++ b/docs/06-testes/casos-teste-ep-002-autenticacao.md
@@ -1,16 +1,16 @@
-# ✅ Casos de Teste — EP-002: Autenticação
+# Casos de Teste — EP-002: Autenticacao
 
-> Casos de teste do Épico 2, elaborados com base nas User Stories de autenticação e nas regras de negócio vigentes, mantendo rastreabilidade completa.
+> Casos de teste do Epico 2, elaborados com base nas User Stories de autenticacao e nas regras de negocio vigentes, mantendo rastreabilidade completa conforme ISO/IEC/IEEE 29119-3.
 
 ---
 
 ## 1. Objetivo
 
-Definir os cenários de teste do EP-002 para validar o login com JWT (`POST /api/auth/login`), o middleware de proteção de rotas e o tratamento dos cenários de token ausente, inválido ou expirado.
+Definir os cenarios de teste do EP-002 para validar o fluxo de autenticacao (login) via API.
 
 ---
 
-## 2. Referências
+## 2. Referencias
 
 - `docs/05-user-stories/ep-002-autenticacao.md`
 - `docs/02-regras-negocio/regras-usuario.md`
@@ -21,258 +21,200 @@ Definir os cenários de teste do EP-002 para validar o login com JWT (`POST /api
 
 ---
 
-## 3. Convenções
+## 3. Convencoes
 
 - **ID do caso:** `CT-EP002-USXXX-YY`
-- **Tipo:** API (automatizável) + execução manual complementar
-- **Rastreabilidade obrigatória:** `US` + `RU/RG`
+- **Tipo:** API (automatizavel) + execucao manual complementar
+- **Rastreabilidade obrigatoria:** `US` + `RU/RG`
 - **Formato esperado de erro:** `{"erro":{"codigo":"...","mensagem":"..."}}`
-- **Rota auxiliar para US-007/US-008:** quando não houver rota protegida real ainda implementada, os casos podem ser executados contra `GET /api/usuarios/me` (após US-002) ou contra rota auxiliar dedicada de testes do middleware.
 
 ---
 
 ## 4. Casos de teste
 
-### US-006 — Autenticar usuário (`POST /api/auth/login`)
+### US-006 — Autenticar usuario (`POST /api/auth/login`)
 
-#### CT-EP002-US006-01 — Login com credenciais válidas
-- **Rastreabilidade:** US-006, RU-021, RU-023, RU-024, RU-026, RG-001
-- **Prioridade:** Alta
-- **Pré-condições:** usuário cadastrado com `email` e `senha` conhecidos
-- **Passos:**
-  1. Enviar `POST /api/auth/login` com `email` e `senha` corretos.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Body com `token` e `usuario`
-  - `usuario` contém `id`, `nome`, `email`
-  - sem `senha` ou `senha_hash`
+#### CT-EP002-US006-01 — Login com credenciais validas
 
-#### CT-EP002-US006-02 — Login com e-mail não cadastrado
-- **Rastreabilidade:** US-006, RU-022
-- **Prioridade:** Alta
-- **Pré-condições:** e-mail informado não existe na base
-- **Passos:**
-  1. Enviar requisição de login com `email` inexistente.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = CREDENCIAIS_INVALIDAS`
-  - mensagem genérica (não revela se o e-mail existe)
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP002-US006-01 |
+| **Titulo** | Validar que o sistema autentica o usuario e retorna token JWT quando credenciais sao validas |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-006, RU-021, RU-023, RU-024, RU-026, RG-001 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema com e-mail e senha conhecidos |
 
-#### CT-EP002-US006-03 — Login com senha incorreta
-- **Rastreabilidade:** US-006, RU-022, RU-026
-- **Prioridade:** Alta
-- **Pré-condições:** usuário cadastrado
-- **Passos:**
-  1. Enviar requisição de login com `email` correto e `senha` errada.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = CREDENCIAIS_INVALIDAS`
-  - resposta idêntica à do CT-EP002-US006-02
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/auth/login` com `email` e `senha` validos | HTTP `200` |
+| 2 | Inspecionar body da resposta | Body contem `token` (string JWT) e objeto `usuario` com `id`, `nome`, `email` |
 
-#### CT-EP002-US006-04 — Login sem campo email
-- **Rastreabilidade:** US-006, RU-021, RG-014
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição de login sem o campo `email`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de obrigatoriedade/validação para `email`
+| **Pos-Condicoes** | - Token JWT valido emitido e pronto para uso em rotas protegidas |
+
+---
+
+#### CT-EP002-US006-02 — Login com e-mail nao cadastrado
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP002-US006-02 |
+| **Titulo** | Validar que o sistema rejeita login quando o e-mail informado nao esta cadastrado |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-006, RU-022 |
+| **Pre-Condicoes** | - Nenhum usuario cadastrado com o e-mail informado |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/auth/login` com e-mail nao cadastrado e senha qualquer | HTTP `401` com `erro.codigo = CREDENCIAIS_INVALIDAS` |
+
+| **Pos-Condicoes** | - Nenhum token emitido |
+
+---
+
+#### CT-EP002-US006-03 — Login com senha incorreta (resposta identica ao CT-02)
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP002-US006-03 |
+| **Titulo** | Validar que o sistema rejeita login com senha incorreta retornando body identico ao cenario de e-mail inexistente |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-006, RU-022, RU-026 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema com e-mail conhecido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/auth/login` com e-mail valido e senha incorreta | HTTP `401` com `erro.codigo = CREDENCIAIS_INVALIDAS` |
+| 2 | Comparar body da resposta com o body retornado no CT-EP002-US006-02 | Body e identico (mesma estrutura e codigo de erro), impedindo enumeracao de usuarios |
+
+| **Pos-Condicoes** | - Nenhum token emitido |
+
+---
+
+#### CT-EP002-US006-04 — Login sem campo e-mail
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP002-US006-04 |
+| **Titulo** | Validar que o sistema rejeita login quando o campo email esta ausente |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-006, RU-021, RG-014 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/auth/login` sem o campo `email` | HTTP `400` com `erro.codigo = CAMPO_OBRIGATORIO` |
+
+| **Pos-Condicoes** | - Nenhum token emitido |
+
+---
 
 #### CT-EP002-US006-05 — Login sem campo senha
-- **Rastreabilidade:** US-006, RU-021, RG-014
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição de login sem o campo `senha`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de obrigatoriedade/validação para `senha`
 
-#### CT-EP002-US006-06 — Body sem JSON válido
-- **Rastreabilidade:** US-006, RG-007
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar requisição de login com body em formato inválido (ex.: texto puro).
-- **Resultado esperado:**
-  - HTTP `400`
-  - `erro.codigo = FORMATO_INVALIDO`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP002-US006-05 |
+| **Titulo** | Validar que o sistema rejeita login quando o campo senha esta ausente |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-006, RU-021, RG-014 |
+| **Pre-Condicoes** | - Nenhuma |
 
-#### CT-EP002-US006-07 — Payload do token contém os campos corretos
-- **Rastreabilidade:** US-006, RU-025, RG-013
-- **Prioridade:** Alta
-- **Pré-condições:** usuário cadastrado
-- **Passos:**
-  1. Realizar login com sucesso.
-  2. Decodificar o token retornado.
-- **Resultado esperado:**
-  - payload contém `sub`, `email`, `iat`, `exp`
-  - `sub` igual ao `id` do usuário
-  - `email` em minúsculas
-  - `exp - iat` corresponde à duração configurada (padrão 24h)
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/auth/login` sem o campo `senha` | HTTP `400` com `erro.codigo = CAMPO_OBRIGATORIO` |
 
-#### CT-EP002-US006-08 — Login case-insensitive no e-mail
-- **Rastreabilidade:** US-006, RU-010, RG-020
-- **Prioridade:** Média
-- **Pré-condições:** usuário cadastrado com e-mail em minúsculas
-- **Passos:**
-  1. Enviar requisição de login com o mesmo e-mail em caixa alta.
-- **Resultado esperado:**
-  - HTTP `200`
-  - login bem-sucedido
-  - `email` no payload do token em minúsculas
-
-#### CT-EP002-US006-09 — Múltiplas sessões simultâneas
-- **Rastreabilidade:** US-006, RU-027
-- **Prioridade:** Média
-- **Pré-condições:** usuário cadastrado
-- **Passos:**
-  1. Realizar login.
-  2. Realizar novo login com as mesmas credenciais.
-  3. Usar ambos os tokens em rota protegida.
-- **Resultado esperado:**
-  - ambos os tokens válidos
-  - login mais recente não invalida o anterior
+| **Pos-Condicoes** | - Nenhum token emitido |
 
 ---
 
-### US-007 — Proteger rotas com JWT (middleware `authMiddleware`)
+#### CT-EP002-US006-06 — Login com body que nao e JSON valido
 
-#### CT-EP002-US007-01 — Acesso autorizado com token válido
-- **Rastreabilidade:** US-007, RG-008
-- **Prioridade:** Alta
-- **Pré-condições:** rota protegida disponível; token JWT válido
-- **Passos:**
-  1. Enviar requisição autenticada com header `Authorization: Bearer <token>`.
-- **Resultado esperado:**
-  - middleware libera a requisição
-  - handler da rota é executado normalmente
-  - resposta corresponde ao contrato da rota
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP002-US006-06 |
+| **Titulo** | Validar que o sistema rejeita login quando o body da requisicao nao e um JSON valido |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-006, RG-007 |
+| **Pre-Condicoes** | - Nenhuma |
 
-#### CT-EP002-US007-02 — req.usuario populado a partir do payload
-- **Rastreabilidade:** US-007, RU-025
-- **Prioridade:** Alta
-- **Pré-condições:** token JWT válido
-- **Passos:**
-  1. Enviar requisição autenticada a uma rota cujo handler retorne ou utilize `req.usuario`.
-- **Resultado esperado:**
-  - `req.usuario.id` igual ao campo `sub` do token
-  - `req.usuario.email` igual ao campo `email` do token
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/auth/login` com body em formato nao-JSON (ex.: texto puro, XML) | HTTP `400` com `erro.codigo = FORMATO_INVALIDO` |
 
-#### CT-EP002-US007-03 — Tokens diferentes identificam usuários diferentes
-- **Rastreabilidade:** US-007, RG-012
-- **Prioridade:** Alta
-- **Pré-condições:** dois usuários distintos com tokens válidos
-- **Passos:**
-  1. Cada usuário envia requisição à mesma rota protegida com seu token.
-- **Resultado esperado:**
-  - cada `req.usuario` corresponde ao dono do respectivo token
-  - nenhum vazamento de identidade entre as requisições
-
-#### CT-EP002-US007-04 — Middleware reutilizável em múltiplas rotas
-- **Rastreabilidade:** US-007, RG-008
-- **Prioridade:** Média
-- **Pré-condições:** middleware aplicado em duas rotas distintas
-- **Passos:**
-  1. Enviar requisições autenticadas com o mesmo token às duas rotas.
-- **Resultado esperado:**
-  - ambas as rotas processam a requisição normalmente
-  - identidade do usuário é resolvida da mesma forma em cada uma
-
-#### CT-EP002-US007-05 — Acesso negado quando o header Authorization está ausente
-- **Rastreabilidade:** US-007, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição a uma rota protegida sem o header `Authorization`.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
-  - handler da rota não é executado
+| **Pos-Condicoes** | - Nenhum token emitido |
 
 ---
 
-### US-008 — Tratar token ausente ou inválido (middleware `authMiddleware`)
+#### CT-EP002-US006-07 — Payload JWT contem campos obrigatorios com expiracao de ~24h
 
-#### CT-EP002-US008-01 — Header Authorization ausente
-- **Rastreabilidade:** US-008, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição a uma rota protegida sem o header `Authorization`.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
-  - mensagem em português
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP002-US006-07 |
+| **Titulo** | Validar que o payload do token JWT contem sub, email, iat e exp com expiracao de aproximadamente 24 horas |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-006, RU-025, RG-013 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema com credenciais conhecidas |
 
-#### CT-EP002-US008-02 — Header Authorization sem prefixo "Bearer"
-- **Rastreabilidade:** US-008, RG-010
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição com header `Authorization` contendo apenas o token, sem o prefixo `Bearer`.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_INVALIDO`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/auth/login` com credenciais validas | HTTP `200` com token JWT |
+| 2 | Decodificar o payload do token JWT (base64) | Payload contem campos `sub` (ID do usuario), `email`, `iat` (timestamp de emissao) e `exp` (timestamp de expiracao) |
+| 3 | Calcular diferenca entre `exp` e `iat` | Diferenca e de aproximadamente 24 horas (86400 segundos) |
 
-#### CT-EP002-US008-03 — Token malformado
-- **Rastreabilidade:** US-008, RG-010
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição com header `Authorization: Bearer <string-sem-estrutura-jwt>` (ex.: `abc.def`).
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_INVALIDO`
+| **Pos-Condicoes** | - Token JWT valido emitido e pronto para uso em rotas protegidas |
 
-#### CT-EP002-US008-04 — Token assinado com chave diferente
-- **Rastreabilidade:** US-008, RG-010, RG-006
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição com token JWT estruturalmente válido, mas assinado com chave secreta distinta da configurada.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_INVALIDO`
+---
 
-#### CT-EP002-US008-05 — Token expirado
-- **Rastreabilidade:** US-008, RG-011, RG-013
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição com token cujo `exp` já tenha passado.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_EXPIRADO`
+#### CT-EP002-US006-08 — Login com e-mail em caixa diferente (case-insensitive)
 
-#### CT-EP002-US008-06 — Estrutura padronizada do erro
-- **Rastreabilidade:** US-008, RG-041, RG-042
-- **Prioridade:** Média
-- **Passos:**
-  1. Provocar qualquer cenário de erro do middleware (CT-EP002-US008-01 a 05).
-  2. Inspecionar o body da resposta.
-- **Resultado esperado:**
-  - body segue `{"erro":{"codigo":"...","mensagem":"..."}}`
-  - `codigo` corresponde ao cenário (`TOKEN_AUSENTE`, `TOKEN_INVALIDO` ou `TOKEN_EXPIRADO`)
-  - `mensagem` em português
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP002-US006-08 |
+| **Titulo** | Validar que o sistema autentica o usuario independentemente da caixa (maiuscula/minuscula) do e-mail |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-006, RU-010, RG-020 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema com e-mail em minusculas |
 
-#### CT-EP002-US008-07 — Erro retorna antes do handler da rota
-- **Rastreabilidade:** US-008, RG-008
-- **Prioridade:** Média
-- **Pré-condições:** handler da rota com efeito observável (ex.: leitura de banco)
-- **Passos:**
-  1. Provocar qualquer cenário de erro do middleware.
-  2. Verificar se o handler da rota foi acionado (logs, side effects, banco).
-- **Resultado esperado:**
-  - handler não é executado
-  - nenhum efeito colateral observável após o erro
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/auth/login` com e-mail em caixa mista (ex.: `User@Email.COM`) e senha correta | HTTP `200` com token JWT e dados do usuario |
+
+| **Pos-Condicoes** | - Token JWT valido emitido e pronto para uso em rotas protegidas |
+
+---
+
+#### CT-EP002-US006-09 — Multiplas sessoes geram tokens distintos
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP002-US006-09 |
+| **Titulo** | Validar que logins consecutivos do mesmo usuario geram tokens JWT distintos e todos permanecem validos |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-006, RU-027 |
+| **Pre-Condicoes** | - Usuario cadastrado no sistema com credenciais conhecidas |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/auth/login` com credenciais validas e armazenar o token retornado (token A) | HTTP `200` com token JWT |
+| 2 | Enviar `POST /api/auth/login` novamente com as mesmas credenciais e armazenar o token retornado (token B) | HTTP `200` com token JWT |
+| 3 | Comparar token A com token B | Tokens sao diferentes (strings distintas) |
+| 4 | Enviar `GET /api/usuarios/me` com token A | HTTP `200` — token A continua valido |
+| 5 | Enviar `GET /api/usuarios/me` com token B | HTTP `200` — token B tambem e valido |
+
+| **Pos-Condicoes** | - Ambos os tokens permanecem validos e funcionais para rotas protegidas |
 
 ---
 
 ## 5. Resumo de cobertura
 
-- **Total de casos:** 21
-- **Distribuição por US:**
-  - US-006: 9
-  - US-007: 5
-  - US-008: 7
+| User Story | Descricao | Quantidade de CTs |
+|---|---|---|
+| US-006 | Autenticar usuario (login) | 9 |
+| **Total** | | **9** |
 
 ---
 
-## 6. Próximos passos
+## 6. Proximos passos
 
-1. Classificar quais casos entram primeiro na automação (`tipo:testes`) por risco (login + token expirado/ausente como mínimos).
-2. Selecionar amostra crítica para execução manual exploratória com evidência (especialmente CT-EP002-US006-02 vs CT-EP002-US006-03 — verificar resposta idêntica para anti-enumeração).
-3. Evoluir para matriz de rastreabilidade de execução (`planejado`, `executado`, `aprovado`, `reprovado`).
+1. Classificar quais casos entram primeiro na automacao (`tipo:testes`) por risco.
+2. Selecionar amostra critica para execucao manual exploratoria com evidencia.
+3. Evoluir para matriz de rastreabilidade de execucao (`planejado`, `executado`, `aprovado`, `reprovado`).

--- a/docs/06-testes/casos-teste-ep-003-contas.md
+++ b/docs/06-testes/casos-teste-ep-003-contas.md
@@ -1,31 +1,27 @@
-# ✅ Casos de Teste — EP-003: Gestão de Contas
+# Casos de Teste — EP-003: Gestao de Contas
 
-> Casos de teste do Épico 3, elaborados com base nas User Stories de contas e nas regras de negócio vigentes, mantendo rastreabilidade completa.
+> Baseado na ISO-29119-3. Casos de teste do Epico 3 com rastreabilidade completa.
 
 ---
 
 ## 1. Objetivo
 
-Definir os cenários de teste do EP-003 para validar criação, listagem, consulta, atualização, desativação e consulta de saldo de contas financeiras.
+Validar criacao, listagem, consulta, atualizacao, desativacao e saldo de contas financeiras.
 
 ---
 
-## 2. Referências
+## 2. Referencias
 
-- `docs/05-user-stories/ep-003-contas.md`
-- `docs/02-regras-negocio/regras-gerais.md`
-- `docs/03-arquitetura/api-contratos.md`
-- `docs/06-testes/estrategia-testes.md`
-- `docs/06-testes/plano-testes-fase-1.md`
+- docs/05-user-stories/ep-003-contas.md
+- docs/02-regras-negocio/regras-conta.md (RC-*)
+- docs/02-regras-negocio/regras-gerais.md (RG-*)
 
 ---
 
-## 3. Convenções
+## 3. Convencoes
 
-- **ID do caso:** `CT-EP003-USXXX-YY`
-- **Tipo:** API (automatizável) + execução manual complementar
-- **Rastreabilidade obrigatória:** `US` + `RC/RG`
-- **Formato esperado de erro:** `{"erro":{"codigo":"...","mensagem":"..."}}`
+- ID: CT-EP003-USXXX-YY
+- Formato: ISO-29119-3 (tabela com passos, acao, resultado)
 
 ---
 
@@ -33,385 +29,765 @@ Definir os cenários de teste do EP-003 para validar criação, listagem, consul
 
 ### US-009 — Criar nova conta (`POST /api/contas`)
 
-#### CT-EP003-US009-01 — Criação com dados válidos
-- **Rastreabilidade:** US-009, RC-001, RC-002
-- **Prioridade:** Alta
-- **Pré-condições:** token JWT válido
-- **Passos:**
-  1. Enviar `POST /api/contas` com `nome`, `tipo`, `saldoInicial` válidos.
-- **Resultado esperado:**
-  - HTTP `201`
-  - Body com `id`, `nome`, `tipo`, `saldoInicial`, `ativo`, `criadoEm`, `atualizadoEm`
+#### CT-EP003-US009-01 — Criar conta corrente com dados validos (nome, tipo, saldoInicial)
 
-#### CT-EP003-US009-02 — Criação com saldoInicial = 0
-- **Rastreabilidade:** US-009, RC-003
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição com `saldoInicial: 0`.
-- **Resultado esperado:**
-  - HTTP `201`
-  - `saldoInicial = 0`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US009-01 |
+| **Titulo** | Validar que uma conta corrente e criada com sucesso ao enviar nome, tipo e saldoInicial validos |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-009, RC-001, RC-002 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
 
-#### CT-EP003-US009-03 — Criação sem saldoInicial (padrão 0)
-- **Rastreabilidade:** US-009, RC-003
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição sem campo `saldoInicial`.
-- **Resultado esperado:**
-  - HTTP `201`
-  - `saldoInicial = 0`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/contas` com header `Authorization: Bearer <token>` e body `{ "nome": "Nubank", "tipo": "corrente", "saldoInicial": 1000 }` | HTTP `201 Created` |
+| 2 | Verificar body da resposta | Body contem `id`, `nome`, `tipo`, `saldoInicial`, `ativo=true`, `criadoEm`, `atualizadoEm` |
 
-#### CT-EP003-US009-04 — Aceitar todos os 5 tipos válidos
-- **Rastreabilidade:** US-009, RC-002
-- **Prioridade:** Alta
-- **Passos:**
-  1. Criar conta para cada tipo: corrente, poupanca, carteira_digital, dinheiro, investimento.
-- **Resultado esperado:**
-  - HTTP `201` para cada tipo
-
-#### CT-EP003-US009-05 — Nome ausente
-- **Rastreabilidade:** US-009, RC-006
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição sem campo `nome`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de obrigatoriedade para `nome`
-
-#### CT-EP003-US009-06 — Tipo inválido
-- **Rastreabilidade:** US-009, RC-002
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `tipo: "invalido"`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro indicando tipos aceitos
-
-#### CT-EP003-US009-07 — Saldo inicial negativo
-- **Rastreabilidade:** US-009, RC-003
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `saldoInicial: -100`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de validação para `saldoInicial`
-
-#### CT-EP003-US009-08 — Tipo ausente
-- **Rastreabilidade:** US-009, RC-002
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição sem campo `tipo`.
-- **Resultado esperado:**
-  - HTTP `400`
-
-#### CT-EP003-US009-09 — Requisição sem token
-- **Rastreabilidade:** US-009, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição sem header `Authorization`.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Conta persistida no banco com `ativo=true` e dados informados |
 
 ---
 
-### US-010 — Listar contas do usuário (`GET /api/contas`)
+#### CT-EP003-US009-02 — Criar conta com saldoInicial igual a zero
 
-#### CT-EP003-US010-01 — Listar contas ativas
-- **Rastreabilidade:** US-010, RC-010
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; contas cadastradas
-- **Passos:**
-  1. Chamar `GET /api/contas`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - apenas contas ativas do usuário
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US009-02 |
+| **Titulo** | Validar que saldoInicial=0 e aceito na criacao de conta |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-009, RC-003 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
 
-#### CT-EP003-US010-02 — Não listar contas inativas por padrão
-- **Rastreabilidade:** US-010, RC-011
-- **Prioridade:** Alta
-- **Pré-condições:** conta desativada existente
-- **Passos:**
-  1. Chamar `GET /api/contas` sem filtro.
-- **Resultado esperado:**
-  - conta inativa ausente da resposta
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/contas` com body `{ "nome": "Conta Zero", "tipo": "corrente", "saldoInicial": 0 }` | HTTP `201 Created` |
+| 2 | Verificar campo `saldoInicial` na resposta | `saldoInicial = 0` |
 
-#### CT-EP003-US010-03 — Listar contas inativas com ?ativo=false
-- **Rastreabilidade:** US-010, RC-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar `GET /api/contas?ativo=false`.
-- **Resultado esperado:**
-  - apenas contas com ativo = false
-
-#### CT-EP003-US010-04 — Filtrar por tipo
-- **Rastreabilidade:** US-010, RC-013
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar `GET /api/contas?tipo=corrente`.
-- **Resultado esperado:**
-  - apenas contas do tipo corrente
-
-#### CT-EP003-US010-05 — Lista vazia
-- **Rastreabilidade:** US-010
-- **Prioridade:** Média
-- **Passos:**
-  1. Chamar `GET /api/contas` sem contas cadastradas.
-- **Resultado esperado:**
-  - HTTP `200`
-  - array vazio
-
-#### CT-EP003-US010-06 — Isolamento entre usuários
-- **Rastreabilidade:** US-010, RG-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Criar contas com dois usuários diferentes.
-  2. Listar contas do usuário A.
-- **Resultado esperado:**
-  - apenas contas do usuário A
-
-#### CT-EP003-US010-07 — Requisição sem token
-- **Rastreabilidade:** US-010, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar endpoint sem token.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Conta criada no banco com `saldoInicial=0` |
 
 ---
 
-### US-011 — Consultar conta específica (`GET /api/contas/:id`)
+#### CT-EP003-US009-03 — Criar conta sem informar saldoInicial (padrao 0)
 
-#### CT-EP003-US011-01 — Consulta com saldoCalculado
-- **Rastreabilidade:** US-011, RC-020
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; conta existente
-- **Passos:**
-  1. Chamar `GET /api/contas/:id`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - body com `saldoCalculado`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US009-03 |
+| **Titulo** | Validar que a omissao do campo saldoInicial resulta em valor padrao 0 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-009, RC-003 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
 
-#### CT-EP003-US011-02 — ID inexistente
-- **Rastreabilidade:** US-011, RC-022
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar `GET /api/contas/99999`.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = CONTA_NAO_ENCONTRADA`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/contas` com body `{ "nome": "Conta Sem Saldo", "tipo": "corrente" }` (sem campo `saldoInicial`) | HTTP `201 Created` |
+| 2 | Verificar campo `saldoInicial` na resposta | `saldoInicial = 0` |
 
-#### CT-EP003-US011-03 — Conta de outro usuário
-- **Rastreabilidade:** US-011, RC-022, RG-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Consultar conta pertencente a outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
+| **Pos-Condicoes** | - Conta criada no banco com `saldoInicial=0` |
 
-#### CT-EP003-US011-04 — Requisição sem token
-- **Rastreabilidade:** US-011, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar endpoint sem token.
-- **Resultado esperado:**
-  - HTTP `401`
+---
+
+#### CT-EP003-US009-04 — Criar conta com cada um dos 5 tipos validos
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US009-04 |
+| **Titulo** | Validar que os 5 tipos de conta validos (corrente, poupanca, carteira_digital, dinheiro, investimento) sao aceitos na criacao |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-009, RC-002 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/contas` com `tipo: "corrente"` | HTTP `201 Created` com `tipo = "corrente"` |
+| 2 | Enviar `POST /api/contas` com `tipo: "poupanca"` | HTTP `201 Created` com `tipo = "poupanca"` |
+| 3 | Enviar `POST /api/contas` com `tipo: "carteira_digital"` | HTTP `201 Created` com `tipo = "carteira_digital"` |
+| 4 | Enviar `POST /api/contas` com `tipo: "dinheiro"` | HTTP `201 Created` com `tipo = "dinheiro"` |
+| 5 | Enviar `POST /api/contas` com `tipo: "investimento"` | HTTP `201 Created` com `tipo = "investimento"` |
+
+| **Pos-Condicoes** | - 5 contas criadas no banco, cada uma com o tipo correspondente |
+
+---
+
+#### CT-EP003-US009-05 — Rejeitar criacao de conta sem campo nome
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US009-05 |
+| **Titulo** | Validar que a ausencia do campo nome retorna erro 400 com detalhes do campo |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-009, RC-006 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/contas` com body `{ "tipo": "corrente" }` (sem campo `nome`) | HTTP `400 Bad Request` |
+| 2 | Verificar corpo do erro | Erro contem detalhes indicando obrigatoriedade do campo `nome` |
+
+| **Pos-Condicoes** | - Nenhuma conta criada no banco |
+
+---
+
+#### CT-EP003-US009-06 — Rejeitar criacao de conta com tipo invalido
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US009-06 |
+| **Titulo** | Validar que um tipo fora da lista de valores aceitos retorna erro 400 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-009, RC-002 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/contas` com body `{ "nome": "Conta X", "tipo": "invalido" }` | HTTP `400 Bad Request` |
+| 2 | Verificar corpo do erro | Erro indica tipos aceitos |
+
+| **Pos-Condicoes** | - Nenhuma conta criada no banco |
+
+---
+
+#### CT-EP003-US009-07 — Rejeitar criacao de conta com saldoInicial negativo
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US009-07 |
+| **Titulo** | Validar que saldoInicial negativo retorna erro 400 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-009, RC-003 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/contas` com body `{ "nome": "Conta", "tipo": "corrente", "saldoInicial": -100 }` | HTTP `400 Bad Request` |
+| 2 | Verificar corpo do erro | Erro de validacao para campo `saldoInicial` |
+
+| **Pos-Condicoes** | - Nenhuma conta criada no banco |
+
+---
+
+#### CT-EP003-US009-08 — Rejeitar criacao de conta sem campo tipo
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US009-08 |
+| **Titulo** | Validar que a ausencia do campo tipo retorna erro 400 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-009, RC-002 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/contas` com body `{ "nome": "Conta Sem Tipo" }` (sem campo `tipo`) | HTTP `400 Bad Request` |
+| 2 | Verificar corpo do erro | Erro indica obrigatoriedade do campo `tipo` |
+
+| **Pos-Condicoes** | - Nenhuma conta criada no banco |
+
+---
+
+#### CT-EP003-US009-09 — Rejeitar criacao de conta sem token de autenticacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US009-09 |
+| **Titulo** | Validar que requisicao sem token JWT retorna 401 com codigo TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-009, RG-009 |
+| **Pre-Condicoes** | - Nenhuma (requisicao sem autenticacao) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `POST /api/contas` sem header `Authorization` | HTTP `401 Unauthorized` |
+| 2 | Verificar corpo do erro | `erro.codigo = "TOKEN_AUSENTE"` |
+
+| **Pos-Condicoes** | - Nenhuma conta criada no banco |
+
+---
+
+### US-010 — Listar contas do usuario (`GET /api/contas`)
+
+#### CT-EP003-US010-01 — Listar contas ativas do usuario autenticado
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US010-01 |
+| **Titulo** | Validar que a listagem retorna array com as contas ativas do usuario |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-010, RC-010 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Usuario possui 2 ou mais contas ativas |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas` com header `Authorization: Bearer <token>` | HTTP `200 OK` |
+| 2 | Verificar body da resposta | Array contendo as contas ativas do usuario |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US010-02 — Nao listar contas inativas por padrao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US010-02 |
+| **Titulo** | Validar que contas inativas nao aparecem na listagem padrao |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-010, RC-011 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Usuario possui 1 conta ativa e 1 conta inativa |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas` sem query parameters | HTTP `200 OK` |
+| 2 | Verificar body da resposta | Array contem apenas a conta ativa; conta inativa ausente |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US010-03 — Listar contas inativas com filtro ativo=false
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US010-03 |
+| **Titulo** | Validar que o filtro ?ativo=false retorna apenas contas inativas |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-010, RC-012 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Usuario possui ao menos 1 conta inativa |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas?ativo=false` | HTTP `200 OK` |
+| 2 | Verificar body da resposta | Array contem apenas contas com `ativo=false` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US010-04 — Filtrar contas por tipo corrente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US010-04 |
+| **Titulo** | Validar que o filtro ?tipo=corrente retorna apenas contas do tipo corrente |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-010, RC-013 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Usuario possui contas de tipos variados |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas?tipo=corrente` | HTTP `200 OK` |
+| 2 | Verificar body da resposta | Array contem apenas contas com `tipo = "corrente"` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US010-05 — Retornar array vazio quando nao ha contas
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US010-05 |
+| **Titulo** | Validar que a listagem retorna array vazio quando o usuario nao possui contas |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-010 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Usuario nao possui nenhuma conta cadastrada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas` | HTTP `200 OK` |
+| 2 | Verificar body da resposta | Array vazio `[]` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US010-06 — Garantir isolamento de contas entre usuarios
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US010-06 |
+| **Titulo** | Validar que cada usuario visualiza apenas suas proprias contas |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-010, RG-012 |
+| **Pre-Condicoes** | - Dois usuarios autenticados (A e B), cada um com contas cadastradas |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas` com token do usuario A | HTTP `200 OK` com apenas contas do usuario A |
+| 2 | Enviar `GET /api/contas` com token do usuario B | HTTP `200 OK` com apenas contas do usuario B |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US010-07 — Rejeitar listagem de contas sem token de autenticacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US010-07 |
+| **Titulo** | Validar que requisicao sem token JWT retorna 401 com codigo TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-010, RG-009 |
+| **Pre-Condicoes** | - Nenhuma (requisicao sem autenticacao) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas` sem header `Authorization` | HTTP `401 Unauthorized` |
+| 2 | Verificar corpo do erro | `erro.codigo = "TOKEN_AUSENTE"` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+### US-011 — Consultar conta especifica (`GET /api/contas/:id`)
+
+#### CT-EP003-US011-01 — Consultar conta existente com saldoCalculado
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US011-01 |
+| **Titulo** | Validar que a consulta de conta retorna os dados completos incluindo saldoCalculado |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-011, RC-020 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta existente com `saldoInicial=1500` |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas/:id` com ID de conta existente | HTTP `200 OK` |
+| 2 | Verificar body da resposta | Body contem dados da conta com campo `saldoCalculado` presente |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US011-02 — Consultar conta com ID inexistente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US011-02 |
+| **Titulo** | Validar que consulta com ID inexistente retorna 404 CONTA_NAO_ENCONTRADA |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-011, RC-022 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas/99999` (ID inexistente) | HTTP `404 Not Found` |
+| 2 | Verificar corpo do erro | `erro.codigo = "CONTA_NAO_ENCONTRADA"` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US011-03 — Rejeitar consulta de conta pertencente a outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US011-03 |
+| **Titulo** | Validar que consulta de conta de outro usuario retorna 404 sem expor dados alheios |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-011, RC-022, RG-012 |
+| **Pre-Condicoes** | - Usuario A autenticado com token JWT valido<br>- Conta pertencente ao usuario B |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas/:id` com ID de conta do usuario B usando token do usuario A | HTTP `404 Not Found` |
+| 2 | Verificar corpo da resposta | Nenhum dado da conta alheia e exposto |
+
+| **Pos-Condicoes** | - Dados da conta do usuario B permanecem inalterados e nao expostos |
+
+---
+
+#### CT-EP003-US011-04 — Rejeitar consulta de conta sem token de autenticacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US011-04 |
+| **Titulo** | Validar que requisicao sem token JWT retorna 401 com codigo TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-011, RG-009 |
+| **Pre-Condicoes** | - Nenhuma (requisicao sem autenticacao) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas/:id` sem header `Authorization` | HTTP `401 Unauthorized` |
+| 2 | Verificar corpo do erro | `erro.codigo = "TOKEN_AUSENTE"` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
 
 ---
 
 ### US-012 — Atualizar dados da conta (`PUT /api/contas/:id`)
 
-#### CT-EP003-US012-01 — Atualização do nome
-- **Rastreabilidade:** US-012, RC-030
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; conta existente
-- **Passos:**
-  1. Enviar `PUT /api/contas/:id` com novo `nome`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - nome atualizado
+#### CT-EP003-US012-01 — Atualizar nome da conta com sucesso
 
-#### CT-EP003-US012-02 — Campo atualizadoEm presente
-- **Rastreabilidade:** US-012, RC-034
-- **Prioridade:** Média
-- **Passos:**
-  1. Atualizar nome da conta.
-- **Resultado esperado:**
-  - campo `atualizadoEm` presente na resposta
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US012-01 |
+| **Titulo** | Validar que o nome da conta e atualizado com sucesso ao enviar novo valor |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-012, RC-030 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta existente e ativa |
 
-#### CT-EP003-US012-03 — Tipo e saldoInicial ignorados
-- **Rastreabilidade:** US-012, RC-031, RC-032
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `tipo` e `saldoInicial` junto com `nome`.
-- **Resultado esperado:**
-  - `tipo` e `saldoInicial` originais preservados
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/contas/:id` com body `{ "nome": "Novo Nome" }` | HTTP `200 OK` |
+| 2 | Verificar body da resposta | Campo `nome` reflete o novo valor `"Novo Nome"` |
 
-#### CT-EP003-US012-04 — Nome vazio rejeitado
-- **Rastreabilidade:** US-012, RC-033
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `nome: ""`.
-- **Resultado esperado:**
-  - HTTP `400`
+| **Pos-Condicoes** | - Nome da conta alterado no banco para `"Novo Nome"` |
 
-#### CT-EP003-US012-05 — Body sem campo nome
-- **Rastreabilidade:** US-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar body vazio `{}`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - `erro.codigo = CORPO_VAZIO`
+---
 
-#### CT-EP003-US012-06 — ID inexistente
-- **Rastreabilidade:** US-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar PUT para conta inexistente.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = CONTA_NAO_ENCONTRADA`
+#### CT-EP003-US012-02 — Verificar campo atualizadoEm presente na resposta
 
-#### CT-EP003-US012-07 — Conta de outro usuário
-- **Rastreabilidade:** US-012, RG-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Atualizar conta pertencente a outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US012-02 |
+| **Titulo** | Validar que o campo atualizadoEm esta presente na resposta apos atualizacao |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-012, RC-034 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta existente e ativa |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/contas/:id` com body `{ "nome": "Nome Atualizado" }` | HTTP `200 OK` |
+| 2 | Verificar body da resposta | Campo `atualizadoEm` presente e com valor atualizado |
+
+| **Pos-Condicoes** | - Campo `atualizadoEm` reflete a data/hora da atualizacao |
+
+---
+
+#### CT-EP003-US012-03 — Garantir que tipo e saldoInicial sao ignorados no body
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US012-03 |
+| **Titulo** | Validar que os campos tipo e saldoInicial enviados no body sao ignorados e preservam valores originais |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-012, RC-031, RC-032 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta existente com `tipo="corrente"` e `saldoInicial=1000` |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/contas/:id` com body `{ "nome": "Nome OK", "tipo": "poupanca", "saldoInicial": 9999 }` | HTTP `200 OK` |
+| 2 | Verificar campos `tipo` e `saldoInicial` na resposta | `tipo = "corrente"` e `saldoInicial = 1000` (valores originais preservados) |
+
+| **Pos-Condicoes** | - Campos `tipo` e `saldoInicial` inalterados no banco |
+
+---
+
+#### CT-EP003-US012-04 — Rejeitar atualizacao com nome vazio
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US012-04 |
+| **Titulo** | Validar que nome vazio retorna erro 400 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-012, RC-033 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta existente e ativa |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/contas/:id` com body `{ "nome": "" }` | HTTP `400 Bad Request` |
+| 2 | Verificar corpo do erro | Erro de validacao para campo `nome` |
+
+| **Pos-Condicoes** | - Nome da conta inalterado no banco |
+
+---
+
+#### CT-EP003-US012-05 — Rejeitar atualizacao com body sem campo nome
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US012-05 |
+| **Titulo** | Validar que body vazio sem campo nome retorna erro 400 CORPO_VAZIO |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-012 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta existente e ativa |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/contas/:id` com body `{}` | HTTP `400 Bad Request` |
+| 2 | Verificar corpo do erro | `erro.codigo = "CORPO_VAZIO"` |
+
+| **Pos-Condicoes** | - Conta inalterada no banco |
+
+---
+
+#### CT-EP003-US012-06 — Rejeitar atualizacao de conta com ID inexistente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US012-06 |
+| **Titulo** | Validar que atualizacao com ID inexistente retorna 404 CONTA_NAO_ENCONTRADA |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-012 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/contas/99999` com body `{ "nome": "Qualquer" }` | HTTP `404 Not Found` |
+| 2 | Verificar corpo do erro | `erro.codigo = "CONTA_NAO_ENCONTRADA"` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US012-07 — Rejeitar atualizacao de conta pertencente a outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US012-07 |
+| **Titulo** | Validar que atualizacao de conta de outro usuario retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-012, RG-012 |
+| **Pre-Condicoes** | - Usuario A autenticado com token JWT valido<br>- Conta pertencente ao usuario B |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `PUT /api/contas/:id` com ID de conta do usuario B usando token do usuario A | HTTP `404 Not Found` |
+
+| **Pos-Condicoes** | - Conta do usuario B permanece inalterada |
 
 ---
 
 ### US-013 — Desativar conta (`DELETE /api/contas/:id`)
 
-#### CT-EP003-US013-01 — Desativação bem-sucedida
-- **Rastreabilidade:** US-013, RC-040
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; conta ativa
-- **Passos:**
-  1. Enviar `DELETE /api/contas/:id`.
-- **Resultado esperado:**
-  - HTTP `204`
-  - sem body
+#### CT-EP003-US013-01 — Desativar conta ativa com sucesso
 
-#### CT-EP003-US013-02 — Conta desativada oculta na listagem
-- **Rastreabilidade:** US-013, RC-042
-- **Prioridade:** Alta
-- **Passos:**
-  1. Desativar conta.
-  2. Listar contas sem filtro.
-- **Resultado esperado:**
-  - conta desativada ausente
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US013-01 |
+| **Titulo** | Validar que a desativacao de conta ativa retorna 204 e define ativo=false |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-013, RC-040 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta existente e ativa |
 
-#### CT-EP003-US013-03 — Conta desativada visível com filtro
-- **Rastreabilidade:** US-013, RC-042
-- **Prioridade:** Alta
-- **Passos:**
-  1. Desativar conta.
-  2. Listar com `?ativo=false`.
-- **Resultado esperado:**
-  - conta desativada presente
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/contas/:id` | HTTP `204 No Content` |
+| 2 | Consultar conta diretamente no banco | Campo `ativo=false`; transacoes vinculadas permanecem intactas |
 
-#### CT-EP003-US013-04 — Desativar conta já inativa
-- **Rastreabilidade:** US-013
-- **Prioridade:** Média
-- **Passos:**
-  1. Desativar conta duas vezes.
-- **Resultado esperado:**
-  - HTTP `400`
-  - `erro.codigo = CONTA_JA_INATIVA`
+| **Pos-Condicoes** | - Conta com `ativo=false` no banco<br>- Transacoes vinculadas a conta preservadas |
 
-#### CT-EP003-US013-05 — ID inexistente
-- **Rastreabilidade:** US-013
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar DELETE para conta inexistente.
-- **Resultado esperado:**
-  - HTTP `404`
+---
 
-#### CT-EP003-US013-06 — Conta de outro usuário
-- **Rastreabilidade:** US-013, RG-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Desativar conta de outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
+#### CT-EP003-US013-02 — Conta desativada nao aparece na listagem padrao
 
-#### CT-EP003-US013-07 — Requisição sem token
-- **Rastreabilidade:** US-013, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar endpoint sem token.
-- **Resultado esperado:**
-  - HTTP `401`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US013-02 |
+| **Titulo** | Validar que conta desativada nao aparece na listagem padrao sem filtro |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-013, RC-042 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta recentemente desativada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Desativar conta via `DELETE /api/contas/:id` | HTTP `204 No Content` |
+| 2 | Enviar `GET /api/contas` sem filtros | HTTP `200 OK`; conta desativada ausente da listagem |
+
+| **Pos-Condicoes** | - Conta permanece inativa no banco |
+
+---
+
+#### CT-EP003-US013-03 — Conta desativada aparece com filtro ativo=false
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US013-03 |
+| **Titulo** | Validar que conta desativada aparece na listagem com filtro ?ativo=false |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-013, RC-042 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta desativada existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas?ativo=false` | HTTP `200 OK` |
+| 2 | Verificar body da resposta | Conta desativada presente no array de resultados |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US013-04 — Rejeitar desativacao de conta ja inativa
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US013-04 |
+| **Titulo** | Validar que desativar conta ja inativa retorna 400 CONTA_JA_INATIVA |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-013 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta ja desativada (`ativo=false`) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/contas/:id` para conta ja inativa | HTTP `400 Bad Request` |
+| 2 | Verificar corpo do erro | `erro.codigo = "CONTA_JA_INATIVA"` |
+
+| **Pos-Condicoes** | - Conta permanece inativa sem alteracoes adicionais |
+
+---
+
+#### CT-EP003-US013-05 — Rejeitar desativacao de conta com ID inexistente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US013-05 |
+| **Titulo** | Validar que desativacao com ID inexistente retorna 404 CONTA_NAO_ENCONTRADA |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-013 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/contas/99999` | HTTP `404 Not Found` |
+| 2 | Verificar corpo do erro | `erro.codigo = "CONTA_NAO_ENCONTRADA"` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US013-06 — Rejeitar desativacao de conta pertencente a outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US013-06 |
+| **Titulo** | Validar que desativacao de conta de outro usuario retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-013, RG-012 |
+| **Pre-Condicoes** | - Usuario A autenticado com token JWT valido<br>- Conta pertencente ao usuario B |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/contas/:id` com ID de conta do usuario B usando token do usuario A | HTTP `404 Not Found` |
+
+| **Pos-Condicoes** | - Conta do usuario B permanece inalterada |
+
+---
+
+#### CT-EP003-US013-07 — Rejeitar desativacao de conta sem token de autenticacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US013-07 |
+| **Titulo** | Validar que requisicao sem token JWT retorna 401 com codigo TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-013, RG-009 |
+| **Pre-Condicoes** | - Nenhuma (requisicao sem autenticacao) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `DELETE /api/contas/:id` sem header `Authorization` | HTTP `401 Unauthorized` |
+| 2 | Verificar corpo do erro | `erro.codigo = "TOKEN_AUSENTE"` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
 
 ---
 
 ### US-014 — Consultar saldo calculado (`GET /api/contas/:id/saldo`)
 
-#### CT-EP003-US014-01 — Conta sem transações retorna saldoInicial
-- **Rastreabilidade:** US-014, RC-052
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; conta com saldoInicial definido
-- **Passos:**
-  1. Chamar `GET /api/contas/:id/saldo`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - `saldoCalculado` = saldoInicial
+#### CT-EP003-US014-01 — Consultar saldo de conta sem transacoes retorna saldoInicial
 
-#### CT-EP003-US014-02 — Conta com saldoInicial = 0
-- **Rastreabilidade:** US-014, RC-052
-- **Prioridade:** Média
-- **Passos:**
-  1. Criar conta com saldoInicial = 0.
-  2. Consultar saldo.
-- **Resultado esperado:**
-  - `saldoCalculado = 0`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US014-01 |
+| **Titulo** | Validar que conta sem transacoes retorna saldoCalculado igual ao saldoInicial |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-014, RC-052 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta existente com `saldoInicial=2500` e sem transacoes |
 
-#### CT-EP003-US014-03 — ID inexistente
-- **Rastreabilidade:** US-014
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar `GET /api/contas/99999/saldo`.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = CONTA_NAO_ENCONTRADA`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas/:id/saldo` | HTTP `200 OK` |
+| 2 | Verificar campo `saldoCalculado` na resposta | `saldoCalculado = 2500` (igual ao saldoInicial) |
 
-#### CT-EP003-US014-04 — Conta de outro usuário
-- **Rastreabilidade:** US-014, RG-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Consultar saldo de conta de outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
 
-#### CT-EP003-US014-05 — Requisição sem token
-- **Rastreabilidade:** US-014, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Chamar endpoint sem token.
-- **Resultado esperado:**
-  - HTTP `401`
+---
+
+#### CT-EP003-US014-02 — Consultar saldo de conta com saldoInicial igual a zero
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US014-02 |
+| **Titulo** | Validar que conta com saldoInicial=0 e sem transacoes retorna saldoCalculado=0 |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-014, RC-052 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido<br>- Conta existente com `saldoInicial=0` e sem transacoes |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas/:id/saldo` | HTTP `200 OK` |
+| 2 | Verificar campo `saldoCalculado` na resposta | `saldoCalculado = 0` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US014-03 — Rejeitar consulta de saldo com ID inexistente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US014-03 |
+| **Titulo** | Validar que consulta de saldo com ID inexistente retorna 404 CONTA_NAO_ENCONTRADA |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-014 |
+| **Pre-Condicoes** | - Usuario autenticado com token JWT valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas/99999/saldo` | HTTP `404 Not Found` |
+| 2 | Verificar corpo do erro | `erro.codigo = "CONTA_NAO_ENCONTRADA"` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
+
+---
+
+#### CT-EP003-US014-04 — Rejeitar consulta de saldo de conta pertencente a outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US014-04 |
+| **Titulo** | Validar que consulta de saldo de conta de outro usuario retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-014, RG-012 |
+| **Pre-Condicoes** | - Usuario A autenticado com token JWT valido<br>- Conta pertencente ao usuario B |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas/:id/saldo` com ID de conta do usuario B usando token do usuario A | HTTP `404 Not Found` |
+
+| **Pos-Condicoes** | - Dados da conta do usuario B nao expostos |
+
+---
+
+#### CT-EP003-US014-05 — Rejeitar consulta de saldo sem token de autenticacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP003-US014-05 |
+| **Titulo** | Validar que requisicao sem token JWT retorna 401 com codigo TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-014, RG-009 |
+| **Pre-Condicoes** | - Nenhuma (requisicao sem autenticacao) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar `GET /api/contas/:id/saldo` sem header `Authorization` | HTTP `401 Unauthorized` |
+| 2 | Verificar corpo do erro | `erro.codigo = "TOKEN_AUSENTE"` |
+
+| **Pos-Condicoes** | - Nenhuma alteracao nos dados |
 
 ---
 
 ## 5. Resumo de cobertura
 
-- **Total de casos:** 39
-- **Distribuição por US:**
-  - US-009: 9
-  - US-010: 7
-  - US-011: 4
-  - US-012: 7
-  - US-013: 7
-  - US-014: 5
-
----
-
-## 6. Próximos passos
-
-1. Todos os 39 casos estão automatizados em `tests/api/contas/`.
-2. Quando EP-005 (Transações) for implementado, adicionar casos para validar `saldoCalculado` com transações reais.
-3. Evoluir para matriz de rastreabilidade de execução.
+| User Story | Endpoint | Casos de Teste | IDs |
+|---|---|:---:|---|
+| US-009 | `POST /api/contas` | 9 | CT-EP003-US009-01 a 09 |
+| US-010 | `GET /api/contas` | 7 | CT-EP003-US010-01 a 07 |
+| US-011 | `GET /api/contas/:id` | 4 | CT-EP003-US011-01 a 04 |
+| US-012 | `PUT /api/contas/:id` | 7 | CT-EP003-US012-01 a 07 |
+| US-013 | `DELETE /api/contas/:id` | 7 | CT-EP003-US013-01 a 07 |
+| US-014 | `GET /api/contas/:id/saldo` | 5 | CT-EP003-US014-01 a 05 |
+| **Total** | | **39** | |

--- a/docs/06-testes/casos-teste-ep-004-categorias.md
+++ b/docs/06-testes/casos-teste-ep-004-categorias.md
@@ -1,16 +1,15 @@
-# ✅ Casos de Teste — EP-004: Gestão de Categorias
-
-> Casos de teste do Épico 4, elaborados com base nas User Stories de categorias e nas regras de negócio vigentes, mantendo rastreabilidade completa.
+# Casos de Teste — EP-004: Gestao de Categorias
+> Baseado na ISO-29119-3. Casos de teste do Epico 4 com rastreabilidade completa.
 
 ---
 
 ## 1. Objetivo
 
-Definir os cenários de teste do EP-004 para validar listagem, criação, consulta, atualização e exclusão de categorias (padrão e personalizadas).
+Definir os cenarios de teste do EP-004 para validar listagem, criacao, consulta, atualizacao e exclusao de categorias (padrao e personalizadas).
 
 ---
 
-## 2. Referências
+## 2. Referencias
 
 - `docs/05-user-stories/ep-004-categorias.md`
 - `docs/02-regras-negocio/regras-gerais.md`
@@ -20,357 +19,651 @@ Definir os cenários de teste do EP-004 para validar listagem, criação, consul
 
 ---
 
-## 3. Convenções
+## 3. Convencoes
 
 - **ID do caso:** `CT-EP004-USXXX-YY`
-- **Tipo:** API (automatizável) + execução manual complementar
-- **Rastreabilidade obrigatória:** `US` + `RK/RG`
+- **Tipo:** API (automatizavel) + execucao manual complementar
+- **Rastreabilidade obrigatoria:** `US` + `RK/RG`
 - **Formato esperado de erro:** `{"erro":{"codigo":"...","mensagem":"..."}}`
 
 ---
 
-## 4. Casos de teste
+## 4. Casos de Teste
 
-### US-015 — Listar categorias (`GET /api/categorias`)
+### US-015 — Listar categorias (GET /api/categorias)
 
-#### CT-EP004-US015-01 — Listagem retorna categorias padrão e personalizadas
-- **Rastreabilidade:** US-015, RK-027, RK-028
-- **Prioridade:** Alta
-- **Pré-condições:** token JWT válido; usuário com categorias personalizadas criadas
-- **Passos:**
-  1. Enviar `GET /api/categorias` com token válido.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Body contém categorias padrão e personalizadas do usuário
-  - Sem categorias personalizadas de outros usuários
+#### CT-EP004-US015-01 — Listar categorias padrao e personalizadas
 
-#### CT-EP004-US015-02 — Filtro por tipo (despesa)
-- **Rastreabilidade:** US-015, RK-029
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/categorias?tipo=despesa`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Todas as categorias retornadas com tipo "despesa" ou "ambos"
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US015-01 |
+| **Titulo** | Validar que o endpoint retorna categorias padrao e personalizadas do usuario autenticado |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-015, RK-027 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Pelo menos 1 categoria personalizada criada pelo usuario |
 
-#### CT-EP004-US015-03 — Filtro por origem (padrao=true)
-- **Rastreabilidade:** US-015, RK-030
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/categorias?padrao=true`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Todas as categorias retornadas com padrao = true
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/categorias com token valido | Status 200 |
+| 2 | Verificar corpo da resposta | Array contendo categorias padrao (padrao=true) e personalizadas (padrao=false) |
 
-#### CT-EP004-US015-04 — Usuário sem categorias personalizadas vê apenas padrão
-- **Rastreabilidade:** US-015, RK-027
-- **Prioridade:** Média
-- **Pré-condições:** usuário sem categorias personalizadas
-- **Passos:**
-  1. Enviar `GET /api/categorias` com token válido.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Apenas as 13 categorias padrão retornadas
-
-#### CT-EP004-US015-05 — Cada categoria contém campos esperados
-- **Rastreabilidade:** US-015, RK-031
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar `GET /api/categorias` com token válido.
-  2. Inspecionar cada item do array.
-- **Resultado esperado:**
-  - Cada categoria contém id, nome, tipo, icone, padrao e criadoEm
-
-#### CT-EP004-US015-06 — Listagem sem token
-- **Rastreabilidade:** US-015, RK-032, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/categorias` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
-
-#### CT-EP004-US015-07 — Filtro por tipo (receita)
-- **Rastreabilidade:** US-015, RK-029
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar `GET /api/categorias?tipo=receita`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Todas as categorias retornadas com tipo "receita" ou "ambos"
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
 
 ---
 
-### US-016 — Criar categoria personalizada (`POST /api/categorias`)
+#### CT-EP004-US015-02 — Categorias padrao aparecem primeiro ordenadas por nome
 
-#### CT-EP004-US016-01 — Criação com dados válidos
-- **Rastreabilidade:** US-016, RK-010, RK-013, RK-014
-- **Prioridade:** Alta
-- **Pré-condições:** token JWT válido
-- **Passos:**
-  1. Enviar `POST /api/categorias` com `nome`, `tipo` válidos.
-- **Resultado esperado:**
-  - HTTP `201`
-  - Body com `id`, `nome`, `tipo`, `icone`, `padrao`, `criadoEm`
-  - `padrao = false`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US015-02 |
+| **Titulo** | Validar que categorias padrao aparecem antes das personalizadas e ordenadas por nome |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-015, RK-028 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categorias padrao e personalizadas existentes |
 
-#### CT-EP004-US016-02 — Criação com ícone opcional
-- **Rastreabilidade:** US-016, RK-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/categorias` com `nome`, `tipo` e `icone`.
-- **Resultado esperado:**
-  - HTTP `201`
-  - `icone` presente no retorno
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/categorias com token valido | Status 200 |
+| 2 | Verificar o primeiro item do array | Primeiro item possui padrao=true |
+| 3 | Verificar ordenacao das categorias padrao | Categorias padrao ordenadas alfabeticamente por nome |
 
-#### CT-EP004-US016-03 — Criação sem ícone
-- **Rastreabilidade:** US-016, RK-012
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar `POST /api/categorias` sem campo `icone`.
-- **Resultado esperado:**
-  - HTTP `201`
-  - `icone` null ou ausente
-
-#### CT-EP004-US016-04 — Tipo inválido
-- **Rastreabilidade:** US-016, RK-011
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição com `tipo` diferente de receita, despesa ou ambos.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de validação no campo tipo
-
-#### CT-EP004-US016-05 — Nome ausente
-- **Rastreabilidade:** US-016, RK-010, RG-014
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar requisição sem campo `nome`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de obrigatoriedade para `nome`
-
-#### CT-EP004-US016-06 — Campo padrao ignorado (forçado false)
-- **Rastreabilidade:** US-016, RK-013
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar requisição com `padrao: true` no corpo.
-- **Resultado esperado:**
-  - HTTP `201`
-  - `padrao = false` independentemente do valor enviado
-
-#### CT-EP004-US016-07 — Criação sem token
-- **Rastreabilidade:** US-016, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/categorias` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
-
-#### CT-EP004-US016-08 — Aceitar todos os 3 tipos válidos
-- **Rastreabilidade:** US-016, RK-011
-- **Prioridade:** Alta
-- **Passos:**
-  1. Criar categoria para cada tipo: receita, despesa, ambos.
-- **Resultado esperado:**
-  - HTTP `201` para cada tipo
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
 
 ---
 
-### US-017 — Consultar categoria (`GET /api/categorias/:id`)
+#### CT-EP004-US015-03 — Filtrar categorias por tipo despesa
 
-#### CT-EP004-US017-01 — Consulta de categoria padrão
-- **Rastreabilidade:** US-017, RK-033
-- **Prioridade:** Alta
-- **Pré-condições:** token JWT válido
-- **Passos:**
-  1. Enviar `GET /api/categorias/:id` com ID de categoria padrão.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Body com `id`, `nome`, `tipo`, `icone`, `padrao`, `criadoEm`
-  - `padrao = true`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US015-03 |
+| **Titulo** | Validar que o filtro ?tipo=despesa retorna apenas categorias de tipo despesa e ambos |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-015, RK-029 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categorias dos tres tipos existentes (receita, despesa, ambos) |
 
-#### CT-EP004-US017-02 — Consulta de categoria personalizada pelo criador
-- **Rastreabilidade:** US-017, RK-034
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/categorias/:id` com ID de categoria personalizada própria.
-- **Resultado esperado:**
-  - HTTP `200`
-  - `padrao = false`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/categorias?tipo=despesa com token valido | Status 200 |
+| 2 | Verificar tipos retornados | Todas as categorias possuem tipo=despesa ou tipo=ambos |
 
-#### CT-EP004-US017-03 — Categoria personalizada de outro usuário retorna 404
-- **Rastreabilidade:** US-017, RK-034, RG-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/categorias/:id` com ID de categoria personalizada de outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = CATEGORIA_NAO_ENCONTRADA`
-
-#### CT-EP004-US017-04 — Categoria inexistente retorna 404
-- **Rastreabilidade:** US-017, RK-035
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/categorias/:id` com ID inexistente.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = CATEGORIA_NAO_ENCONTRADA`
-
-#### CT-EP004-US017-05 — Consulta sem token
-- **Rastreabilidade:** US-017, RK-036, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/categorias/:id` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
 
 ---
 
-### US-018 — Atualizar categoria personalizada (`PUT /api/categorias/:id`)
+#### CT-EP004-US015-04 — Filtrar categorias por origem padrao
 
-#### CT-EP004-US018-01 — Atualização completa de nome e ícone
-- **Rastreabilidade:** US-018, RK-037, RK-043
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; categoria personalizada própria
-- **Passos:**
-  1. Enviar `PUT /api/categorias/:id` com novo `nome` e novo `icone`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - dados atualizados retornados
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US015-04 |
+| **Titulo** | Validar que o filtro ?origem=padrao retorna apenas categorias padrao |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-015, RK-030 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
 
-#### CT-EP004-US018-02 — Atualização parcial apenas do nome
-- **Rastreabilidade:** US-018, RK-038
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar atualização apenas com `nome`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - apenas o nome alterado
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/categorias?origem=padrao com token valido | Status 200 |
+| 2 | Verificar campo padrao de cada item | Todas as categorias possuem padrao=true |
 
-#### CT-EP004-US018-03 — Tipo é imutável
-- **Rastreabilidade:** US-018, RK-039
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar atualização tentando alterar o campo `tipo`.
-- **Resultado esperado:**
-  - campo tipo permanece inalterado
-  - ou HTTP `400` indicando que tipo não pode ser alterado
-
-#### CT-EP004-US018-04 — Tentativa de atualizar categoria padrão retorna 403
-- **Rastreabilidade:** US-018, RK-040
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `PUT /api/categorias/:id` com ID de categoria padrão.
-- **Resultado esperado:**
-  - HTTP `403`
-  - `erro.codigo = ACESSO_NEGADO`
-
-#### CT-EP004-US018-05 — Categoria personalizada de outro usuário retorna 404
-- **Rastreabilidade:** US-018, RK-041, RG-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `PUT /api/categorias/:id` com ID de categoria personalizada de outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = CATEGORIA_NAO_ENCONTRADA`
-
-#### CT-EP004-US018-06 — Categoria inexistente retorna 404
-- **Rastreabilidade:** US-018, RK-041
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar `PUT /api/categorias/:id` com ID inexistente.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = CATEGORIA_NAO_ENCONTRADA`
-
-#### CT-EP004-US018-07 — Nome inválido na atualização
-- **Rastreabilidade:** US-018, RK-037
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar nome vazio ou inválido.
-- **Resultado esperado:**
-  - HTTP `400`
-  - erro de validação
-
-#### CT-EP004-US018-08 — Atualização sem token
-- **Rastreabilidade:** US-018, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `PUT /api/categorias/:id` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
 
 ---
 
-### US-019 — Excluir categoria personalizada (`DELETE /api/categorias/:id`)
+#### CT-EP004-US015-05 — Filtrar categorias por origem personalizada
 
-#### CT-EP004-US019-01 — Exclusão de categoria sem transações
-- **Rastreabilidade:** US-019, RK-044, RK-048
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; categoria personalizada própria sem transações
-- **Passos:**
-  1. Enviar `DELETE /api/categorias/:id` com ID de categoria personalizada sem transações.
-- **Resultado esperado:**
-  - HTTP `204`
-  - sem body de resposta
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US015-05 |
+| **Titulo** | Validar que o filtro ?origem=personalizada retorna apenas categorias personalizadas |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-015, RK-030 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Pelo menos 1 categoria personalizada criada |
 
-#### CT-EP004-US019-02 — Exclusão bloqueada por transações vinculadas
-- **Rastreabilidade:** US-019, RK-045
-- **Prioridade:** Alta
-- **Pré-condições:** categoria personalizada com transações associadas
-- **Passos:**
-  1. Enviar `DELETE /api/categorias/:id` com ID de categoria em uso.
-- **Resultado esperado:**
-  - HTTP `409`
-  - `erro.codigo = CATEGORIA_EM_USO`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/categorias?origem=personalizada com token valido | Status 200 |
+| 2 | Verificar campo padrao de cada item | Todas as categorias possuem padrao=false |
 
-#### CT-EP004-US019-03 — Tentativa de excluir categoria padrão retorna 403
-- **Rastreabilidade:** US-019, RK-046
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `DELETE /api/categorias/:id` com ID de categoria padrão.
-- **Resultado esperado:**
-  - HTTP `403`
-  - `erro.codigo = ACESSO_NEGADO`
-
-#### CT-EP004-US019-04 — Categoria personalizada de outro usuário retorna 404
-- **Rastreabilidade:** US-019, RK-047, RG-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `DELETE /api/categorias/:id` com ID de categoria personalizada de outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = CATEGORIA_NAO_ENCONTRADA`
-
-#### CT-EP004-US019-05 — Exclusão sem token
-- **Rastreabilidade:** US-019, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `DELETE /api/categorias/:id` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
 
 ---
 
-## 5. Resumo de cobertura
+#### CT-EP004-US015-06 — Isolamento de categorias personalizadas entre usuarios
 
-- **Total de casos:** 33
-- **Distribuição por US:**
-  - US-015: 7
-  - US-016: 8
-  - US-017: 5
-  - US-018: 8
-  - US-019: 5
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US015-06 |
+| **Titulo** | Validar que um usuario nao visualiza categorias personalizadas de outro usuario |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-015, RK-003 |
+| **Pre-Condicoes** | - Dois usuarios cadastrados (user1 e user2)\n- user2 possui categoria personalizada criada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Autenticar como user1 | Token valido de user1 |
+| 2 | Enviar GET /api/categorias com token de user1 | Status 200 |
+| 3 | Verificar categorias personalizadas retornadas | Nenhuma categoria personalizada de user2 aparece na lista |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
 
 ---
 
-## 6. Próximos passos
+#### CT-EP004-US015-07 — Listar categorias sem token
 
-1. Classificar quais casos entram primeiro na automação (`tipo:testes`) por risco.
-2. Selecionar amostra crítica para execução manual exploratória com evidência.
-3. Evoluir para matriz de rastreabilidade de execução (`planejado`, `executado`, `aprovado`, `reprovado`).
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US015-07 |
+| **Titulo** | Validar que a listagem sem token retorna 401 TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-015, RG-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/categorias sem header Authorization | Status 401 com codigo TOKEN_AUSENTE |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+### US-016 — Criar categoria (POST /api/categorias)
+
+#### CT-EP004-US016-01 — Criar categoria personalizada valida
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US016-01 |
+| **Titulo** | Validar que uma categoria personalizada e criada com nome, tipo e icone validos |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-016, RK-010, RK-012 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/categorias com body {nome, tipo, icone} validos | Status 201 |
+| 2 | Verificar campo padrao na resposta | padrao=false |
+| 3 | Verificar campos nome, tipo e icone | Valores correspondem ao enviado |
+
+| **Pos-Condicoes** | - Categoria personalizada persistida no banco de dados |
+
+---
+
+#### CT-EP004-US016-02 — Criar categoria sem icone
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US016-02 |
+| **Titulo** | Validar que uma categoria pode ser criada sem icone, resultando em icone=null |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-016, RK-023 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/categorias com body {nome, tipo} sem campo icone | Status 201 |
+| 2 | Verificar campo icone na resposta | icone=null |
+
+| **Pos-Condicoes** | - Categoria criada no banco com icone nulo |
+
+---
+
+#### CT-EP004-US016-03 — Aceitar os tres tipos validos
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US016-03 |
+| **Titulo** | Validar que os tipos receita, despesa e ambos sao aceitos na criacao |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-016, RK-004 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/categorias com tipo=receita | Status 201 |
+| 2 | Enviar POST /api/categorias com tipo=despesa | Status 201 |
+| 3 | Enviar POST /api/categorias com tipo=ambos | Status 201 |
+
+| **Pos-Condicoes** | - Tres categorias criadas no banco |
+
+---
+
+#### CT-EP004-US016-04 — Campo padrao=true no body e ignorado
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US016-04 |
+| **Titulo** | Validar que enviar padrao=true no body e ignorado e a categoria e criada como padrao=false |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-016, RK-008 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/categorias com body incluindo padrao=true | Status 201 |
+| 2 | Verificar campo padrao na resposta | padrao=false |
+
+| **Pos-Condicoes** | - Categoria criada como personalizada (padrao=false) |
+
+---
+
+#### CT-EP004-US016-05 — Criar categoria sem nome
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US016-05 |
+| **Titulo** | Validar que criar categoria sem nome retorna erro 400 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-016, RK-010 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/categorias com body sem campo nome | Status 400 com mensagem de validacao |
+
+| **Pos-Condicoes** | - Nenhuma categoria criada no banco |
+
+---
+
+#### CT-EP004-US016-06 — Criar categoria com tipo invalido
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US016-06 |
+| **Titulo** | Validar que criar categoria com tipo invalido retorna erro 400 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-016, RK-020 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/categorias com tipo="invalido" | Status 400 com mensagem de validacao |
+
+| **Pos-Condicoes** | - Nenhuma categoria criada no banco |
+
+---
+
+#### CT-EP004-US016-07 — Criar categoria com nome apenas numeros
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US016-07 |
+| **Titulo** | Validar que criar categoria com nome contendo apenas numeros retorna erro 400 |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-016, RK-017 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/categorias com nome="12345" | Status 400 com mensagem de validacao |
+
+| **Pos-Condicoes** | - Nenhuma categoria criada no banco |
+
+---
+
+#### CT-EP004-US016-08 — Criar categoria sem token
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US016-08 |
+| **Titulo** | Validar que criar categoria sem token retorna 401 TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-016, RG-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/categorias sem header Authorization | Status 401 com codigo TOKEN_AUSENTE |
+
+| **Pos-Condicoes** | - Nenhuma categoria criada no banco |
+
+---
+
+### US-017 — Consultar categoria por ID (GET /api/categorias/:id)
+
+#### CT-EP004-US017-01 — Consultar categoria padrao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US017-01 |
+| **Titulo** | Validar que e possivel consultar uma categoria padrao pelo ID |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-017, RK-034 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria padrao com id=1 existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/categorias/1 com token valido | Status 200 |
+| 2 | Verificar campo padrao na resposta | padrao=true |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP004-US017-02 — Consultar categoria personalizada propria
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US017-02 |
+| **Titulo** | Validar que e possivel consultar uma categoria personalizada propria pelo ID |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-017, RK-033 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria personalizada criada pelo proprio usuario |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/categorias/:id da categoria propria com token valido | Status 200 |
+| 2 | Verificar dados da categoria | Dados correspondem a categoria criada pelo usuario |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP004-US017-03 — Consultar categoria com ID inexistente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US017-03 |
+| **Titulo** | Validar que consultar categoria com ID inexistente retorna 404 CATEGORIA_NAO_ENCONTRADA |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-017, RK-036 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/categorias/99999 com token valido | Status 404 com codigo CATEGORIA_NAO_ENCONTRADA |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP004-US017-04 — Consultar categoria personalizada de outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US017-04 |
+| **Titulo** | Validar que consultar categoria personalizada de outro usuario retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-017, RK-035 |
+| **Pre-Condicoes** | - Dois usuarios cadastrados\n- user2 possui categoria personalizada criada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Autenticar como user1 | Token valido de user1 |
+| 2 | Enviar GET /api/categorias/:id da categoria de user2 | Status 404 |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP004-US017-05 — Consultar categoria sem token
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US017-05 |
+| **Titulo** | Validar que consultar categoria sem token retorna 401 TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-017, RG-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/categorias/:id sem header Authorization | Status 401 com codigo TOKEN_AUSENTE |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+### US-018 — Atualizar categoria (PUT /api/categorias/:id)
+
+#### CT-EP004-US018-01 — Atualizar nome da categoria
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US018-01 |
+| **Titulo** | Validar que e possivel atualizar o nome de uma categoria personalizada |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-018, RK-038 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria personalizada propria existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/categorias/:id com body {nome: "Novo Nome"} | Status 200 |
+| 2 | Verificar campo nome na resposta | nome="Novo Nome" |
+
+| **Pos-Condicoes** | - Nome da categoria alterado no banco de dados |
+
+---
+
+#### CT-EP004-US018-02 — Atualizar icone da categoria
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US018-02 |
+| **Titulo** | Validar que e possivel atualizar o icone de uma categoria personalizada |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-018, RK-038 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria personalizada propria existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/categorias/:id com body {icone: "novo-icone"} | Status 200 |
+| 2 | Verificar campo icone na resposta | icone="novo-icone" |
+
+| **Pos-Condicoes** | - Icone da categoria alterado no banco de dados |
+
+---
+
+#### CT-EP004-US018-03 — Remover icone da categoria
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US018-03 |
+| **Titulo** | Validar que e possivel remover o icone enviando null |
+| **Prioridade** | Baixa |
+| **Rastreabilidade** | US-018, RK-042 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria personalizada com icone definido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/categorias/:id com body {icone: null} | Status 200 |
+| 2 | Verificar campo icone na resposta | icone=null |
+
+| **Pos-Condicoes** | - Icone removido da categoria no banco |
+
+---
+
+#### CT-EP004-US018-04 — Editar categoria padrao retorna 403
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US018-04 |
+| **Titulo** | Validar que tentar editar uma categoria padrao retorna 403 ACESSO_NEGADO |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-018, RK-049 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria padrao existente (ex: id=1) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/categorias/1 com body {nome: "Tentativa"} | Status 403 com codigo ACESSO_NEGADO |
+
+| **Pos-Condicoes** | - Categoria padrao permanece inalterada no banco |
+
+---
+
+#### CT-EP004-US018-05 — Atualizar categoria com body vazio
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US018-05 |
+| **Titulo** | Validar que enviar body vazio retorna 400 CORPO_VAZIO |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-018 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria personalizada propria existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/categorias/:id com body vazio {} | Status 400 com codigo CORPO_VAZIO |
+
+| **Pos-Condicoes** | - Categoria permanece inalterada no banco |
+
+---
+
+#### CT-EP004-US018-06 — Atualizar categoria com nome vazio
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US018-06 |
+| **Titulo** | Validar que enviar nome vazio retorna erro 400 |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-018, RK-041 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria personalizada propria existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/categorias/:id com body {nome: ""} | Status 400 com mensagem de validacao |
+
+| **Pos-Condicoes** | - Categoria permanece inalterada no banco |
+
+---
+
+#### CT-EP004-US018-07 — Atualizar categoria com ID inexistente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US018-07 |
+| **Titulo** | Validar que atualizar categoria com ID inexistente retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-018 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/categorias/99999 com body {nome: "Teste"} | Status 404 |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP004-US018-08 — Atualizar categoria personalizada de outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US018-08 |
+| **Titulo** | Validar que atualizar categoria personalizada de outro usuario retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-018, RK-037 |
+| **Pre-Condicoes** | - Dois usuarios cadastrados\n- user2 possui categoria personalizada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Autenticar como user1 | Token valido de user1 |
+| 2 | Enviar PUT /api/categorias/:id da categoria de user2 com body {nome: "Hack"} | Status 404 |
+
+| **Pos-Condicoes** | - Categoria de user2 permanece inalterada no banco |
+
+---
+
+### US-019 — Excluir categoria (DELETE /api/categorias/:id)
+
+#### CT-EP004-US019-01 — Excluir categoria personalizada sem transacoes
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US019-01 |
+| **Titulo** | Validar que e possivel excluir categoria personalizada sem transacoes vinculadas |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-019, RK-045, RK-047 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria personalizada propria sem transacoes vinculadas |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar DELETE /api/categorias/:id com token valido | Status 204 |
+| 2 | Enviar GET /api/categorias/:id para verificar exclusao | Status 404 |
+
+| **Pos-Condicoes** | - Categoria removida do banco de dados (hard delete) |
+
+---
+
+#### CT-EP004-US019-02 — Excluir categoria padrao retorna 403
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US019-02 |
+| **Titulo** | Validar que tentar excluir uma categoria padrao retorna 403 ACESSO_NEGADO |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-019, RK-044 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria padrao existente (ex: id=1) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar DELETE /api/categorias/1 com token valido | Status 403 com codigo ACESSO_NEGADO |
+
+| **Pos-Condicoes** | - Categoria padrao permanece inalterada no banco |
+
+---
+
+#### CT-EP004-US019-03 — Excluir categoria com ID inexistente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US019-03 |
+| **Titulo** | Validar que excluir categoria com ID inexistente retorna 404 CATEGORIA_NAO_ENCONTRADA |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-019 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar DELETE /api/categorias/99999 com token valido | Status 404 com codigo CATEGORIA_NAO_ENCONTRADA |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP004-US019-04 — Excluir categoria personalizada de outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US019-04 |
+| **Titulo** | Validar que excluir categoria personalizada de outro usuario retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-019, RK-044 |
+| **Pre-Condicoes** | - Dois usuarios cadastrados\n- user2 possui categoria personalizada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Autenticar como user1 | Token valido de user1 |
+| 2 | Enviar DELETE /api/categorias/:id da categoria de user2 | Status 404 |
+
+| **Pos-Condicoes** | - Categoria de user2 permanece inalterada no banco |
+
+---
+
+#### CT-EP004-US019-05 — Excluir categoria sem token
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP004-US019-05 |
+| **Titulo** | Validar que excluir categoria sem token retorna 401 TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-019, RG-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar DELETE /api/categorias/:id sem header Authorization | Status 401 com codigo TOKEN_AUSENTE |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+## 5. Resumo
+
+| User Story | Quantidade de CTs |
+|---|---|
+| US-015 — GET /api/categorias | 7 |
+| US-016 — POST /api/categorias | 8 |
+| US-017 — GET /api/categorias/:id | 5 |
+| US-018 — PUT /api/categorias/:id | 8 |
+| US-019 — DELETE /api/categorias/:id | 5 |
+| **Total** | **33** |

--- a/docs/06-testes/casos-teste-ep-005-transacoes.md
+++ b/docs/06-testes/casos-teste-ep-005-transacoes.md
@@ -1,16 +1,15 @@
-# ✅ Casos de Teste — EP-005: Gestão de Transações
-
-> Casos de teste do Épico 5, elaborados com base nas User Stories de transações e nas regras de negócio vigentes, mantendo rastreabilidade completa.
+# Casos de Teste — EP-005: Gestao de Transacoes
+> Baseado na ISO-29119-3. Casos de teste do Epico 5 com rastreabilidade completa.
 
 ---
 
 ## 1. Objetivo
 
-Definir os cenários de teste do EP-005 para validar registro, listagem, consulta, atualização, exclusão e busca de transações financeiras.
+Definir os cenarios de teste do EP-005 para validar registro, listagem, consulta, atualizacao, exclusao e busca de transacoes financeiras.
 
 ---
 
-## 2. Referências
+## 2. Referencias
 
 - `docs/05-user-stories/ep-005-transacoes.md`
 - `docs/02-regras-negocio/regras-transacao.md`
@@ -21,429 +20,782 @@ Definir os cenários de teste do EP-005 para validar registro, listagem, consult
 
 ---
 
-## 3. Convenções
+## 3. Convencoes
 
 - **ID do caso:** `CT-EP005-USXXX-YY`
-- **Tipo:** API (automatizável) + execução manual complementar
-- **Rastreabilidade obrigatória:** `US` + `RT/RG`
+- **Tipo:** API (automatizavel) + execucao manual complementar
+- **Rastreabilidade obrigatoria:** `US` + `RT/RG`
 - **Formato esperado de erro:** `{"erro":{"codigo":"...","mensagem":"..."}}`
 
 ---
 
-## 4. Casos de teste
+## 4. Casos de Teste
 
-### US-020 — Registrar transação (`POST /api/transacoes`)
+### US-020 — Registrar transacao (POST /api/transacoes)
 
-#### CT-EP005-US020-01 — Criação bem-sucedida com dados válidos
-- **Rastreabilidade:** US-020, RT-004, RT-007
-- **Prioridade:** Alta
-- **Pré-condições:** token JWT válido; conta ativa pertencente ao usuário; categoria compatível com o tipo
-- **Passos:**
-  1. Enviar `POST /api/transacoes` com tipo, valor, descricao, dataTransacao, contaId e categoriaId válidos.
-- **Resultado esperado:**
-  - HTTP `201`
-  - Body com `id`, `tipo`, `valor`, `descricao`, `dataTransacao`, `contaId`, `categoriaId`, `criadoEm`, `atualizadoEm`
+#### CT-EP005-US020-01 — Criar despesa valida
 
-#### CT-EP005-US020-02 — Conta inexistente retorna 404
-- **Rastreabilidade:** US-020, RT-028
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/transacoes` com `contaId` inexistente.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = CONTA_NAO_ENCONTRADA`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-01 |
+| **Titulo** | Validar que uma despesa valida e registrada com sucesso |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-020, RT-004, RT-007 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Conta ativa existente\n- Categoria do tipo despesa existente |
 
-#### CT-EP005-US020-03 — Conta de outro usuário retorna 404
-- **Rastreabilidade:** US-020, RT-027
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/transacoes` com `contaId` pertencente a outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = CONTA_NAO_ENCONTRADA`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes com body {tipo: "despesa", valor, descricao, data, contaId, categoriaId} | Status 201 |
+| 2 | Verificar campos da resposta | tipo=despesa, demais campos correspondem ao enviado |
 
-#### CT-EP005-US020-04 — Conta inativa retorna 422
-- **Rastreabilidade:** US-020, RT-029
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/transacoes` com `contaId` de conta com `ativa = false`.
-- **Resultado esperado:**
-  - HTTP `422`
-  - `erro.codigo = CONTA_INATIVA`
-
-#### CT-EP005-US020-05 — Categoria incompatível com tipo retorna 422
-- **Rastreabilidade:** US-020, RT-033
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/transacoes` com tipo "receita" e categoriaId exclusivamente de despesa.
-- **Resultado esperado:**
-  - HTTP `422`
-  - `erro.codigo = CATEGORIA_INCOMPATIVEL`
-
-#### CT-EP005-US020-06 — Campo obrigatório ausente retorna 400
-- **Rastreabilidade:** US-020, RT-004, RG-014
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/transacoes` omitindo o campo `valor`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - `erro.codigo = CAMPO_OBRIGATORIO`
-
-#### CT-EP005-US020-07 — Tipo inválido retorna 400
-- **Rastreabilidade:** US-020, RT-009, RT-010
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/transacoes` com `tipo` diferente de "receita" ou "despesa".
-- **Resultado esperado:**
-  - HTTP `400`
-  - `erro.codigo = FORMATO_INVALIDO`
-
-#### CT-EP005-US020-08 — Valor zero ou negativo retorna 422
-- **Rastreabilidade:** US-020, RT-002, RT-013
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/transacoes` com `valor` = 0.
-  2. Enviar `POST /api/transacoes` com `valor` = -50.
-- **Resultado esperado:**
-  - HTTP `422`
-  - `erro.codigo = VALOR_INVALIDO`
-
-#### CT-EP005-US020-09 — Data em formato inválido retorna 400
-- **Rastreabilidade:** US-020, RT-022, RT-025
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/transacoes` com `dataTransacao` = "22/04/2026".
-- **Resultado esperado:**
-  - HTTP `400`
-  - `erro.codigo = FORMATO_INVALIDO`
-
-#### CT-EP005-US020-10 — Descrição vazia retorna 400
-- **Rastreabilidade:** US-020, RT-019
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar `POST /api/transacoes` com `descricao` = "   " (apenas espaços).
-- **Resultado esperado:**
-  - HTTP `400`
-  - `erro.codigo = CAMPO_OBRIGATORIO`
-
-#### CT-EP005-US020-11 — Criação sem token
-- **Rastreabilidade:** US-020, RT-005, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `POST /api/transacoes` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Transacao persistida no banco de dados\n- Saldo da conta ajustado (decrementado) |
 
 ---
 
-### US-021 — Listar transações com filtros (`GET /api/transacoes`)
+#### CT-EP005-US020-02 — Criar receita valida
 
-#### CT-EP005-US021-01 — Listagem retorna apenas transações do usuário autenticado
-- **Rastreabilidade:** US-021, RT-036
-- **Prioridade:** Alta
-- **Pré-condições:** token JWT válido; transações de múltiplos usuários no sistema
-- **Passos:**
-  1. Enviar `GET /api/transacoes` com token válido.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Body contém apenas transações vinculadas às contas do usuário autenticado
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-02 |
+| **Titulo** | Validar que uma receita valida e registrada com sucesso |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-020, RT-001 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Conta ativa existente\n- Categoria do tipo receita existente |
 
-#### CT-EP005-US021-02 — Ordem padrão por data descendente
-- **Rastreabilidade:** US-021, RT-037
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/transacoes` sem parâmetros de ordenação.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Transações ordenadas por `dataTransacao` descendente
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes com body {tipo: "receita", valor, descricao, data, contaId, categoriaId} | Status 201 |
+| 2 | Verificar campo tipo na resposta | tipo=receita |
 
-#### CT-EP005-US021-03 — Filtro por tipo
-- **Rastreabilidade:** US-021, RT-041
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/transacoes?tipo=despesa`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Todas as transações retornadas com tipo "despesa"
-
-#### CT-EP005-US021-04 — Filtro por intervalo de datas
-- **Rastreabilidade:** US-021, RT-044
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/transacoes?de=2026-04-01&ate=2026-04-30`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Todas as transações dentro do intervalo informado
-
-#### CT-EP005-US021-05 — Combinação de múltiplos filtros
-- **Rastreabilidade:** US-021, RT-046
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/transacoes?tipo=despesa&contaId=1&categoriaId=3`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Transações atendem a todos os filtros simultaneamente
-
-#### CT-EP005-US021-06 — Listagem sem token
-- **Rastreabilidade:** US-021, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/transacoes` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Transacao persistida no banco\n- Saldo da conta aumentado |
 
 ---
 
-### US-022 — Consultar transação específica (`GET /api/transacoes/:id`)
+#### CT-EP005-US020-03 — Impacto no saldo apos despesa
 
-#### CT-EP005-US022-01 — Consulta bem-sucedida
-- **Rastreabilidade:** US-022, RT-049, RT-052
-- **Prioridade:** Alta
-- **Pré-condições:** token JWT válido; transação pertencente ao usuário
-- **Passos:**
-  1. Enviar `GET /api/transacoes/:id` com ID de transação própria.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Body com `id`, `tipo`, `valor`, `descricao`, `dataTransacao`, `conta`, `categoria`, `criadoEm`, `atualizadoEm`
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-03 |
+| **Titulo** | Validar que o saldo da conta e ajustado corretamente apos registrar despesa |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-020, RT-066 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Conta com saldoInicial=5000 |
 
-#### CT-EP005-US022-02 — Transação de outro usuário retorna 404
-- **Rastreabilidade:** US-022, RT-050, RT-074
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/transacoes/:id` com ID de transação de outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = RECURSO_NAO_ENCONTRADO`
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes com despesa valor=200 na conta | Status 201 |
+| 2 | Consultar saldo da conta via GET /api/contas/:id | Saldo = 4800 (5000 - 200) |
 
-#### CT-EP005-US022-03 — Transação inexistente retorna 404
-- **Rastreabilidade:** US-022, RT-051
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/transacoes/:id` com ID inexistente.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = RECURSO_NAO_ENCONTRADO`
-
-#### CT-EP005-US022-04 — Consulta sem token
-- **Rastreabilidade:** US-022, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/transacoes/:id` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Saldo da conta atualizado para 4800 |
 
 ---
 
-### US-023 — Atualizar transação (`PUT /api/transacoes/:id`)
+#### CT-EP005-US020-04 — Valor menor ou igual a zero
 
-#### CT-EP005-US023-01 — Atualização bem-sucedida de valor e descrição
-- **Rastreabilidade:** US-023, RT-053, RT-058
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; transação própria em conta ativa
-- **Passos:**
-  1. Enviar `PUT /api/transacoes/:id` com novo `valor` e nova `descricao`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Dados atualizados retornados
-  - `atualizadoEm` com timestamp recente
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-04 |
+| **Titulo** | Validar que transacao com valor menor ou igual a zero retorna 400 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-020, RT-013 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
 
-#### CT-EP005-US023-02 — Atualização parcial apenas da categoria
-- **Rastreabilidade:** US-023, RT-034, RT-055
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `PUT /api/transacoes/:id` apenas com `categoriaId`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Apenas a categoria alterada; demais campos inalterados
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes com valor=0 | Status 400 com mensagem de validacao |
+| 2 | Enviar POST /api/transacoes com valor=-100 | Status 400 com mensagem de validacao |
 
-#### CT-EP005-US023-03 — Tipo é imutável
-- **Rastreabilidade:** US-023, RT-012, RT-054
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `PUT /api/transacoes/:id` tentando alterar o campo `tipo`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - `erro.codigo = CAMPO_IMUTAVEL`
-
-#### CT-EP005-US023-04 — ContaId é imutável
-- **Rastreabilidade:** US-023, RT-030, RT-054
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `PUT /api/transacoes/:id` tentando alterar o campo `contaId`.
-- **Resultado esperado:**
-  - HTTP `400`
-  - `erro.codigo = CAMPO_IMUTAVEL`
-
-#### CT-EP005-US023-05 — Nova categoria incompatível com tipo retorna 422
-- **Rastreabilidade:** US-023, RT-035
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `PUT /api/transacoes/:id` com `categoriaId` exclusivamente de tipo diferente.
-- **Resultado esperado:**
-  - HTTP `422`
-  - `erro.codigo = CATEGORIA_INCOMPATIVEL`
-
-#### CT-EP005-US023-06 — Atualização em conta inativa retorna 422
-- **Rastreabilidade:** US-023, RT-057
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `PUT /api/transacoes/:id` para transação em conta com `ativa = false`.
-- **Resultado esperado:**
-  - HTTP `422`
-  - `erro.codigo = CONTA_INATIVA`
-
-#### CT-EP005-US023-07 — Transação de outro usuário retorna 404
-- **Rastreabilidade:** US-023, RG-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `PUT /api/transacoes/:id` com ID de transação de outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = RECURSO_NAO_ENCONTRADO`
-
-#### CT-EP005-US023-08 — Atualização sem token
-- **Rastreabilidade:** US-023, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `PUT /api/transacoes/:id` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Nenhuma transacao criada no banco |
 
 ---
 
-### US-024 — Excluir transação (`DELETE /api/transacoes/:id`)
+#### CT-EP005-US020-05 — Tipo invalido
 
-#### CT-EP005-US024-01 — Exclusão bem-sucedida
-- **Rastreabilidade:** US-024, RT-060, RT-064
-- **Prioridade:** Alta
-- **Pré-condições:** token válido; transação própria
-- **Passos:**
-  1. Enviar `DELETE /api/transacoes/:id` com ID de transação própria.
-- **Resultado esperado:**
-  - HTTP `204`
-  - Sem body de resposta
-  - Transação removida permanentemente
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-05 |
+| **Titulo** | Validar que transacao com tipo invalido retorna 400 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-020, RT-009 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
 
-#### CT-EP005-US024-02 — Saldo recalculado após exclusão
-- **Rastreabilidade:** US-024, RT-065, RT-068
-- **Prioridade:** Alta
-- **Pré-condições:** conta com saldo calculado considerando a transação
-- **Passos:**
-  1. Consultar saldo da conta antes da exclusão.
-  2. Enviar `DELETE /api/transacoes/:id`.
-  3. Consultar saldo da conta após a exclusão.
-- **Resultado esperado:**
-  - Saldo recalculado sem a transação excluída
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes com tipo="invalido" | Status 400 com mensagem de validacao |
 
-#### CT-EP005-US024-03 — Exclusão em conta inativa é permitida
-- **Rastreabilidade:** US-024, RT-063
-- **Prioridade:** Média
-- **Pré-condições:** transação em conta com `ativa = false`
-- **Passos:**
-  1. Enviar `DELETE /api/transacoes/:id` para transação em conta inativa.
-- **Resultado esperado:**
-  - HTTP `204`
-  - Transação removida normalmente
-
-#### CT-EP005-US024-04 — Transação de outro usuário retorna 404
-- **Rastreabilidade:** US-024, RT-062, RG-012
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `DELETE /api/transacoes/:id` com ID de transação de outro usuário.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = RECURSO_NAO_ENCONTRADO`
-
-#### CT-EP005-US024-05 — Transação inexistente retorna 404
-- **Rastreabilidade:** US-024, RT-062
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `DELETE /api/transacoes/:id` com ID inexistente.
-- **Resultado esperado:**
-  - HTTP `404`
-  - `erro.codigo = RECURSO_NAO_ENCONTRADO`
-
-#### CT-EP005-US024-06 — Exclusão sem token
-- **Rastreabilidade:** US-024, RT-061, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `DELETE /api/transacoes/:id` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Nenhuma transacao criada no banco |
 
 ---
 
-### US-025 — Buscar transações por descrição (`GET /api/transacoes?q=`)
+#### CT-EP005-US020-06 — Descricao vazia
 
-#### CT-EP005-US025-01 — Busca por substring encontra transações
-- **Rastreabilidade:** US-025, RT-045
-- **Prioridade:** Alta
-- **Pré-condições:** token JWT válido; transações com "Mercado" na descrição
-- **Passos:**
-  1. Enviar `GET /api/transacoes?q=mercado`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Todas as transações retornadas contêm "mercado" na descrição
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-06 |
+| **Titulo** | Validar que transacao com descricao vazia retorna 400 |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-020, RT-019 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
 
-#### CT-EP005-US025-02 — Busca é case-insensitive
-- **Rastreabilidade:** US-025, RT-045
-- **Prioridade:** Alta
-- **Pré-condições:** transação com descrição "Almoço com clientes"
-- **Passos:**
-  1. Enviar `GET /api/transacoes?q=ALMOÇO`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Transação com "Almoço com clientes" retornada
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes com descricao="" | Status 400 com mensagem de validacao |
 
-#### CT-EP005-US025-03 — Busca combinada com filtros
-- **Rastreabilidade:** US-025, RT-045, RT-046
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/transacoes?q=mercado&tipo=despesa&contaId=1`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Transações atendem a todos os critérios simultaneamente
-
-#### CT-EP005-US025-04 — Busca sem resultados retorna array vazio
-- **Rastreabilidade:** US-025, RT-045
-- **Prioridade:** Média
-- **Passos:**
-  1. Enviar `GET /api/transacoes?q=xyzabcdefghijk`.
-- **Resultado esperado:**
-  - HTTP `200`
-  - Array vazio no body
-
-#### CT-EP005-US025-05 — Busca sem token
-- **Rastreabilidade:** US-025, RG-009
-- **Prioridade:** Alta
-- **Passos:**
-  1. Enviar `GET /api/transacoes?q=mercado` sem header Authorization.
-- **Resultado esperado:**
-  - HTTP `401`
-  - `erro.codigo = TOKEN_AUSENTE`
+| **Pos-Condicoes** | - Nenhuma transacao criada no banco |
 
 ---
 
-## 5. Resumo de cobertura
+#### CT-EP005-US020-07 — Data invalida
 
-- **Total de casos:** 40
-- **Distribuição por US:**
-  - US-020: 11
-  - US-021: 6
-  - US-022: 4
-  - US-023: 8
-  - US-024: 6
-  - US-025: 5
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-07 |
+| **Titulo** | Validar que transacao com data invalida retorna 400 |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-020, RT-025 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes com data="data-invalida" | Status 400 com mensagem de validacao |
+
+| **Pos-Condicoes** | - Nenhuma transacao criada no banco |
 
 ---
 
-## 6. Próximos passos
+#### CT-EP005-US020-08 — Conta inexistente
 
-1. Classificar quais casos entram primeiro na automação (`tipo:testes`) por risco.
-2. Selecionar amostra crítica para execução manual exploratória com evidência.
-3. Evoluir para matriz de rastreabilidade de execução (`planejado`, `executado`, `aprovado`, `reprovado`).
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-08 |
+| **Titulo** | Validar que transacao com conta inexistente retorna 404 CONTA_NAO_ENCONTRADA |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-020, RT-028 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes com contaId=99999 | Status 404 com codigo CONTA_NAO_ENCONTRADA |
+
+| **Pos-Condicoes** | - Nenhuma transacao criada no banco |
+
+---
+
+#### CT-EP005-US020-09 — Categoria incompativel com tipo da transacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-09 |
+| **Titulo** | Validar que transacao despesa com categoria tipo receita retorna 422 CATEGORIA_INCOMPATIVEL |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-020, RK-005 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Categoria do tipo receita existente\n- Conta ativa existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes com tipo=despesa e categoriaId de categoria tipo=receita | Status 422 com codigo CATEGORIA_INCOMPATIVEL |
+
+| **Pos-Condicoes** | - Nenhuma transacao criada no banco |
+
+---
+
+#### CT-EP005-US020-10 — Conta inativa
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-10 |
+| **Titulo** | Validar que transacao em conta inativa retorna 422 CONTA_INATIVA |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-020, RT-029 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Conta inativa existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes com contaId de conta inativa | Status 422 com codigo CONTA_INATIVA |
+
+| **Pos-Condicoes** | - Nenhuma transacao criada no banco |
+
+---
+
+#### CT-EP005-US020-11 — Criar transacao sem token
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US020-11 |
+| **Titulo** | Validar que criar transacao sem token retorna 401 TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-020, RG-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar POST /api/transacoes sem header Authorization | Status 401 com codigo TOKEN_AUSENTE |
+
+| **Pos-Condicoes** | - Nenhuma transacao criada no banco |
+
+---
+
+### US-021 — Listar transacoes (GET /api/transacoes)
+
+#### CT-EP005-US021-01 — Listar transacoes do usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US021-01 |
+| **Titulo** | Validar que o endpoint retorna as transacoes do usuario autenticado |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-021, RT-036 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- 2 ou mais transacoes cadastradas |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes com token valido | Status 200 |
+| 2 | Verificar corpo da resposta | Array com as transacoes do usuario |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US021-02 — Filtrar por tipo despesa
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US021-02 |
+| **Titulo** | Validar que o filtro ?tipo=despesa retorna apenas transacoes de despesa |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-021, RT-041 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacoes de receita e despesa cadastradas |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes?tipo=despesa com token valido | Status 200 |
+| 2 | Verificar tipos retornados | Todas as transacoes possuem tipo=despesa |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US021-03 — Filtrar por periodo
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US021-03 |
+| **Titulo** | Validar que o filtro por periodo retorna transacoes dentro do intervalo informado |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-021, RT-044 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacoes com datas variadas cadastradas |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes?dataInicio=2026-01-01&dataFim=2026-01-31 com token valido | Status 200 |
+| 2 | Verificar datas das transacoes retornadas | Todas dentro do periodo 2026-01-01 a 2026-01-31 |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US021-04 — Lista vazia
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US021-04 |
+| **Titulo** | Validar que usuario sem transacoes recebe array vazio |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-021 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Nenhuma transacao cadastrada para o usuario |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes com token valido | Status 200 com body [] |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US021-05 — Isolamento entre usuarios
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US021-05 |
+| **Titulo** | Validar que um usuario nao visualiza transacoes de outro usuario |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-021, RT-074 |
+| **Pre-Condicoes** | - Dois usuarios cadastrados (user1 e user2)\n- user2 possui transacoes cadastradas |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Autenticar como user1 | Token valido de user1 |
+| 2 | Enviar GET /api/transacoes com token de user1 | Status 200 |
+| 3 | Verificar transacoes retornadas | Nenhuma transacao de user2 aparece na lista |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US021-06 — Listar transacoes sem token
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US021-06 |
+| **Titulo** | Validar que listar transacoes sem token retorna 401 TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-021, RG-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes sem header Authorization | Status 401 com codigo TOKEN_AUSENTE |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+### US-022 — Consultar transacao por ID (GET /api/transacoes/:id)
+
+#### CT-EP005-US022-01 — Consultar transacao existente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US022-01 |
+| **Titulo** | Validar que e possivel consultar uma transacao existente pelo ID com todos os campos |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-022, RT-049 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacao propria existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes/:id com token valido | Status 200 |
+| 2 | Verificar campos da resposta | Todos os campos presentes (id, tipo, valor, descricao, data, contaId, categoriaId) |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US022-02 — Consultar transacao com ID inexistente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US022-02 |
+| **Titulo** | Validar que consultar transacao com ID inexistente retorna 404 TRANSACAO_NAO_ENCONTRADA |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-022, RT-051 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes/99999 com token valido | Status 404 com codigo TRANSACAO_NAO_ENCONTRADA |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US022-03 — Consultar transacao de outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US022-03 |
+| **Titulo** | Validar que consultar transacao de outro usuario retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-022, RT-050 |
+| **Pre-Condicoes** | - Dois usuarios cadastrados\n- user2 possui transacao cadastrada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Autenticar como user1 | Token valido de user1 |
+| 2 | Enviar GET /api/transacoes/:id da transacao de user2 | Status 404 |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US022-04 — Consultar transacao sem token
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US022-04 |
+| **Titulo** | Validar que consultar transacao sem token retorna 401 TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-022, RG-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes/:id sem header Authorization | Status 401 com codigo TOKEN_AUSENTE |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+### US-023 — Atualizar transacao (PUT /api/transacoes/:id)
+
+#### CT-EP005-US023-01 — Atualizar valor e descricao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US023-01 |
+| **Titulo** | Validar que e possivel atualizar valor e descricao de uma transacao |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-023, RT-053 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacao propria existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/transacoes/:id com body {valor: 150, descricao: "Atualizado"} | Status 200 |
+| 2 | Verificar campos na resposta | valor=150, descricao="Atualizado" |
+
+| **Pos-Condicoes** | - Campos da transacao alterados no banco de dados |
+
+---
+
+#### CT-EP005-US023-02 — Alterar categoriaId
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US023-02 |
+| **Titulo** | Validar que e possivel alterar a categoria de uma transacao |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-023, RT-034 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacao propria existente\n- Categoria compativel com o tipo da transacao |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/transacoes/:id com body {categoriaId: novaCategoria} | Status 200 |
+| 2 | Verificar categoriaId na resposta | categoriaId atualizado para o novo valor |
+
+| **Pos-Condicoes** | - categoriaId da transacao alterado no banco |
+
+---
+
+#### CT-EP005-US023-03 — Tipo e contaId sao imutaveis
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US023-03 |
+| **Titulo** | Validar que tipo e contaId sao preservados mesmo se enviados no body |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-023, RT-054 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacao propria existente (tipo=despesa, contaId=X) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/transacoes/:id com body {tipo: "receita", contaId: 99999, descricao: "Teste"} | Status 200 |
+| 2 | Verificar tipo e contaId na resposta | tipo=despesa (original preservado), contaId=X (original preservado) |
+
+| **Pos-Condicoes** | - tipo e contaId permanecem inalterados no banco |
+
+---
+
+#### CT-EP005-US023-04 — Saldo reflete valor atualizado
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US023-04 |
+| **Titulo** | Validar que o saldo da conta e recalculado apos atualizacao do valor da transacao |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-023, RT-059 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Conta com saldoInicial=5000\n- Despesa de valor=200 ja registrada (saldo atual=4800) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/transacoes/:id com body {valor: 500} | Status 200 |
+| 2 | Consultar saldo da conta via GET /api/contas/:id | Saldo = 4500 (5000 - 500) |
+
+| **Pos-Condicoes** | - Saldo da conta atualizado para 4500 |
+
+---
+
+#### CT-EP005-US023-05 — Atualizar transacao com body vazio
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US023-05 |
+| **Titulo** | Validar que enviar body vazio retorna 400 CORPO_VAZIO |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-023 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacao propria existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/transacoes/:id com body vazio {} | Status 400 com codigo CORPO_VAZIO |
+
+| **Pos-Condicoes** | - Transacao permanece inalterada no banco |
+
+---
+
+#### CT-EP005-US023-06 — Categoria incompativel na atualizacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US023-06 |
+| **Titulo** | Validar que atualizar com categoria incompativel retorna 422 CATEGORIA_INCOMPATIVEL |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-023, RT-033 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacao tipo=despesa existente\n- Categoria tipo=receita existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/transacoes/:id com body {categoriaId: categoriaReceita} | Status 422 com codigo CATEGORIA_INCOMPATIVEL |
+
+| **Pos-Condicoes** | - Transacao permanece inalterada no banco |
+
+---
+
+#### CT-EP005-US023-07 — Atualizar transacao com ID inexistente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US023-07 |
+| **Titulo** | Validar que atualizar transacao com ID inexistente retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-023 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar PUT /api/transacoes/99999 com body {descricao: "Teste"} | Status 404 |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US023-08 — Atualizar transacao de outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US023-08 |
+| **Titulo** | Validar que atualizar transacao de outro usuario retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-023 |
+| **Pre-Condicoes** | - Dois usuarios cadastrados\n- user2 possui transacao cadastrada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Autenticar como user1 | Token valido de user1 |
+| 2 | Enviar PUT /api/transacoes/:id da transacao de user2 com body {descricao: "Hack"} | Status 404 |
+
+| **Pos-Condicoes** | - Transacao de user2 permanece inalterada no banco |
+
+---
+
+### US-024 — Excluir transacao (DELETE /api/transacoes/:id)
+
+#### CT-EP005-US024-01 — Excluir transacao
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US024-01 |
+| **Titulo** | Validar que e possivel excluir uma transacao propria |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-024, RT-060, RT-064 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacao propria existente |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar DELETE /api/transacoes/:id com token valido | Status 204 |
+| 2 | Enviar GET /api/transacoes/:id para verificar exclusao | Status 404 |
+
+| **Pos-Condicoes** | - Transacao removida do banco de dados (hard delete) |
+
+---
+
+#### CT-EP005-US024-02 — Saldo recalculado apos excluir despesa
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US024-02 |
+| **Titulo** | Validar que o saldo e recalculado apos excluir uma despesa |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-024, RT-065, RT-068 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Conta com saldoInicial=5000\n- Despesa de 200 registrada (saldo atual=4800) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar DELETE /api/transacoes/:id da despesa | Status 204 |
+| 2 | Consultar saldo da conta via GET /api/contas/:id | Saldo = 5000 (4800 + 200 devolvido) |
+
+| **Pos-Condicoes** | - Saldo da conta restaurado para 5000 |
+
+---
+
+#### CT-EP005-US024-03 — Saldo recalculado apos excluir receita
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US024-03 |
+| **Titulo** | Validar que o saldo e recalculado apos excluir uma receita |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-024, RT-065 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Conta com saldoInicial=5000\n- Receita de 500 registrada (saldo atual=5500) |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar DELETE /api/transacoes/:id da receita | Status 204 |
+| 2 | Consultar saldo da conta via GET /api/contas/:id | Saldo = 5000 (5500 - 500 removido) |
+
+| **Pos-Condicoes** | - Saldo da conta restaurado para 5000 |
+
+---
+
+#### CT-EP005-US024-04 — Excluir transacao com ID inexistente
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US024-04 |
+| **Titulo** | Validar que excluir transacao com ID inexistente retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-024 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar DELETE /api/transacoes/99999 com token valido | Status 404 |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US024-05 — Excluir transacao de outro usuario
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US024-05 |
+| **Titulo** | Validar que excluir transacao de outro usuario retorna 404 |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-024, RT-062 |
+| **Pre-Condicoes** | - Dois usuarios cadastrados\n- user2 possui transacao cadastrada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Autenticar como user1 | Token valido de user1 |
+| 2 | Enviar DELETE /api/transacoes/:id da transacao de user2 | Status 404 |
+
+| **Pos-Condicoes** | - Transacao de user2 permanece inalterada no banco |
+
+---
+
+#### CT-EP005-US024-06 — Excluir transacao sem token
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US024-06 |
+| **Titulo** | Validar que excluir transacao sem token retorna 401 TOKEN_AUSENTE |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-024, RG-009 |
+| **Pre-Condicoes** | - Nenhuma |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar DELETE /api/transacoes/:id sem header Authorization | Status 401 com codigo TOKEN_AUSENTE |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+### US-025 — Buscar transacoes (GET /api/transacoes?q=)
+
+#### CT-EP005-US025-01 — Buscar por termo
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US025-01 |
+| **Titulo** | Validar que a busca por termo retorna transacoes correspondentes |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-025, RT-045 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacao com descricao contendo "supermercado" cadastrada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes?q=supermercado com token valido | Status 200 |
+| 2 | Verificar resultados | Array contendo transacoes cuja descricao contem "supermercado" |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US025-02 — Busca case-insensitive
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US025-02 |
+| **Titulo** | Validar que a busca e case-insensitive |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-025, RT-045 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacao com descricao "Netflix" cadastrada |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes?q=netflix com token valido | Status 200 com resultado |
+| 2 | Enviar GET /api/transacoes?q=NETFLIX com token valido | Status 200 com mesmo resultado |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US025-03 — Combinar busca com filtro tipo
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US025-03 |
+| **Titulo** | Validar que combinar ?q= com ?tipo= aplica AND logico |
+| **Prioridade** | Media |
+| **Rastreabilidade** | US-025, RT-046 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido\n- Transacoes de receita e despesa com descricoes variadas |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes?q=supermercado&tipo=despesa com token valido | Status 200 |
+| 2 | Verificar resultados | Apenas transacoes tipo=despesa contendo "supermercado" na descricao |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US025-04 — Busca sem resultados
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US025-04 |
+| **Titulo** | Validar que busca sem resultados retorna array vazio |
+| **Prioridade** | Baixa |
+| **Rastreabilidade** | US-025 |
+| **Pre-Condicoes** | - Usuario autenticado com token valido |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Enviar GET /api/transacoes?q=termoInexistente com token valido | Status 200 com body [] |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+#### CT-EP005-US025-05 — Isolamento de busca entre usuarios
+
+| Campo | Valor |
+|---|---|
+| **ID** | CT-EP005-US025-05 |
+| **Titulo** | Validar que a busca retorna apenas transacoes do proprio usuario |
+| **Prioridade** | Alta |
+| **Rastreabilidade** | US-025, RT-074 |
+| **Pre-Condicoes** | - Dois usuarios cadastrados\n- user2 possui transacao com descricao "Netflix" |
+
+| Passo | Acao | Resultado Esperado |
+|---|---|---|
+| 1 | Autenticar como user1 | Token valido de user1 |
+| 2 | Enviar GET /api/transacoes?q=Netflix com token de user1 | Status 200 |
+| 3 | Verificar resultados | Nenhuma transacao de user2 aparece nos resultados |
+
+| **Pos-Condicoes** | - Nenhuma alteracao no banco de dados |
+
+---
+
+## 5. Resumo
+
+| User Story | Quantidade de CTs |
+|---|---|
+| US-020 — POST /api/transacoes | 11 |
+| US-021 — GET /api/transacoes | 6 |
+| US-022 — GET /api/transacoes/:id | 4 |
+| US-023 — PUT /api/transacoes/:id | 8 |
+| US-024 — DELETE /api/transacoes/:id | 6 |
+| US-025 — GET /api/transacoes?q= | 5 |
+| **Total** | **40** |


### PR DESCRIPTION
## Summary
- Reescreve os 5 documentos de casos de teste (EP-001 a EP-005) no formato ISO-29119-3
- Baseado no modelo `exemploCasosDeTest.docx` do projeto
- Rastreabilidade completa preservada em todos os casos

## Formato aplicado (ISO-29119-3)
Cada caso de teste agora contém:
- **ID** + **Título** descritivo longo
- **Prioridade** (Alta/Média/Baixa)
- **Rastreabilidade** (US + regras RU/RC/RK/RT/RG)
- **Pré-Condições** (lista)
- **Tabela de Passos** (Passo | Ação | Resultado Esperado)
- **Pós-Condições** (estado esperado após o teste)

## Cobertura
| Documento | CTs |
|---|---|
| EP-001 Usuários | 39 |
| EP-002 Autenticação | 9 |
| EP-003 Contas | 39 |
| EP-004 Categorias | 33 |
| EP-005 Transações | 40 |
| **Total** | **160** |

## Test plan
- [x] Todos os 160 CTs mantêm IDs originais (CT-EPXXX-USXXX-YY)
- [x] Rastreabilidade 1:1 com testes automatizados (164 testes)
- [x] Pós-condições adicionadas em todos os casos