### PR TITLE
fix(ci): corrige job 'Bugs Conhecidos' que rodava suite inteira

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,8 +96,11 @@ jobs:
           sed -i 's/it\.skip(/it(/' tests/api/transacoes/conta-inativa.test.js
 
       - name: Executar testes de bugs conhecidos (falhas esperadas)
+        env:
+          NODE_ENV: test
         run: |
           npx mocha \
+            --no-config \
             tests/api/usuarios/xss.test.js \
             tests/api/transacoes/conta-inativa.test.js \
             --timeout 10000 \


### PR DESCRIPTION
## Sintoma

O job `Bugs Conhecidos` no CI estava falhando com 25 erros do tipo:

> `Error: limparBanco() so pode ser chamado com NODE_ENV=test. Operacao bloqueada para proteger dados de desenvolvimento.`

A mensagem nao era um problema de privacidade da API — era um guardrail do helper de testes que protege o banco de dev de ser apagado.

## Causa raiz

Dois bugs no step `Executar testes de bugs conhecidos`:

1. **`NODE_ENV` nao era `test`** — o `npm test` (job 1) usa `cross-env NODE_ENV=test`, mas o job 2 chamava `npx mocha` direto sem setar o env. O helper `limparBanco()` aborta nessa condicao.
2. **`.mocharc.yml` sobrepunha os args** — config tem `spec: tests/api/**/*.test.js`, entao mesmo passando `xss.test.js` e `conta-inativa.test.js` como argumentos posicionais, mocha rodava os 159 testes.

## Correcao

```yaml
- name: Executar testes de bugs conhecidos (falhas esperadas)
  env:
    NODE_ENV: test          # <-- novo
  run: |
    npx mocha \
      --no-config \         # <-- novo
      tests/api/usuarios/xss.test.js \
      tests/api/transacoes/conta-inativa.test.js \
      ...
```

## Validacao local

Simulando o CI (`NODE_ENV=test` + `sed` removendo `it.skip` + mocha com `--no-config`):

- Roda exatamente **5 testes** (4 do xss + 1 do conta-inativa)
- Falham por **AssertionError** (bugs reproduzidos):
  - `expected 201 to equal 400` — XSS aceito (#89)
  - `expected 200 to equal 422` — PUT em conta inativa aceito (#90)

## Test plan

- [ ] CI roda apos merge: job 1 verde (159 passing + 5 pending)
- [ ] Job 2 vermelho com **5 testes falhando** (nao 25), todos por `AssertionError`
- [ ] Workflow geral verde gracas a `continue-on-error: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)